### PR TITLE
Reduce Gas Usage: Modify DepositRecord structs #117

### DIFF
--- a/contracts/handlers/ERC20Handler.sol
+++ b/contracts/handlers/ERC20Handler.sol
@@ -14,9 +14,9 @@ import "@openzeppelin/contracts/presets/ERC20PresetMinterPauser.sol";
 contract ERC20Handler is IDepositExecute, HandlerHelpers, ERC20Safe {
     struct DepositRecord {
         address _tokenAddress;
+        uint8    _lenDestinationRecipientAddress;
         uint8   _destinationChainID;
         bytes32 _resourceID;
-        uint    _lenDestinationRecipientAddress;
         bytes   _destinationRecipientAddress;
         address _depositer;
         uint    _amount;
@@ -127,9 +127,9 @@ contract ERC20Handler is IDepositExecute, HandlerHelpers, ERC20Safe {
 
         _depositRecords[destinationChainID][depositNonce] = DepositRecord(
             tokenAddress,
+            uint8(lenRecipientAddress),
             destinationChainID,
             resourceID,
-            lenRecipientAddress,
             recipientAddress,
             depositer,
             amount

--- a/contracts/handlers/ERC721Handler.sol
+++ b/contracts/handlers/ERC721Handler.sol
@@ -149,7 +149,7 @@ contract ERC721Handler is IDepositExecute, HandlerHelpers, ERC721Safe {
         _depositRecords[destinationChainID][depositNonce] = DepositRecord(
             tokenAddress,
             uint8(lenDestinationRecipientAddress),
-            destinationChainID,
+            uint8(destinationChainID),
             resourceID,
             destinationRecipientAddress,
             depositer,

--- a/contracts/handlers/ERC721Handler.sol
+++ b/contracts/handlers/ERC721Handler.sol
@@ -21,9 +21,9 @@ contract ERC721Handler is IDepositExecute, HandlerHelpers, ERC721Safe {
 
     struct DepositRecord {
         address _tokenAddress;
+        uint8    _lenDestinationRecipientAddress;
         uint8   _destinationChainID;
         bytes32 _resourceID;
-        uint    _lenDestinationRecipientAddress;
         bytes   _destinationRecipientAddress;
         address _depositer;
         uint    _tokenID;
@@ -148,9 +148,9 @@ contract ERC721Handler is IDepositExecute, HandlerHelpers, ERC721Safe {
 
         _depositRecords[destinationChainID][depositNonce] = DepositRecord(
             tokenAddress,
-            uint8(destinationChainID),
+            uint8(lenDestinationRecipientAddress),
+            destinationChainID,
             resourceID,
-            lenDestinationRecipientAddress,
             destinationRecipientAddress,
             depositer,
             tokenID,

--- a/contracts/handlers/GenericHandler.sol
+++ b/contracts/handlers/GenericHandler.sol
@@ -13,8 +13,8 @@ contract GenericHandler is IGenericHandler {
 
     struct DepositRecord {
         uint8   _destinationChainID;
-        bytes32 _resourceID;
         address _depositer;
+        bytes32 _resourceID;
         bytes   _metaData;
     }
 
@@ -179,8 +179,8 @@ contract GenericHandler is IGenericHandler {
 
         _depositRecords[destinationChainID][depositNonce] = DepositRecord(
             destinationChainID,
-            resourceID,
             depositer,
+            resourceID,
             metadata
         );
     }

--- a/test/e2e/erc721/erc721SameChain.js
+++ b/test/e2e/erc721/erc721SameChain.js
@@ -86,9 +86,9 @@ contract('E2E ERC721 - Same Chain', async accounts => {
 
         const record = await ERC721HandlerInstance.getDepositRecord(expectedDepositNonce, chainID)
         assert.strictEqual(record[0], ERC721MintableInstance.address)
-        assert.strictEqual(record[1], chainID.toString())
-        assert.strictEqual(record[2], resourceID.toLowerCase())
-        assert.strictEqual(Number(record[3]), 20)
+        assert.strictEqual(record[2], chainID.toString())
+        assert.strictEqual(record[3], resourceID.toLowerCase())
+        assert.strictEqual(Number(record[1]), 20)
         assert.strictEqual(record[4], recipientAddress.toLowerCase())
         assert.strictEqual(record[5], depositerAddress)
         assert.strictEqual(Number(record[6]), tokenID)


### PR DESCRIPTION
Issue: https://github.com/ChainSafe/chainbridge-solidity/issues/117
<!--
 Before submitting a PR please ensure all code is commented and all tests are passing. Make sure to review the changes and ensure that only required changes are included (eg. no unnecessary reformatting by your editor)
-->

<!-- Brief but specific list of changes made, describe the change in functionality rather than the change in code -->
## Changes
- modified the order within the DepositRecord struct to cut down on storage slots
- ERC20 
```
 struct DepositRecord { // now packed together
        address _tokenAddress; // 20 bytes
        uint8   _destinationChainID;  //8 bits
        uint8    _lenDestinationRecipientAddress; // 8 bits
        ...
} 
```
- ERC721
```
 struct DepositRecord { // now packed together
        address _tokenAddress; // 20 bytes
        uint8    _lenDestinationRecipientAddress; // 8 bits
        uint8   _destinationChainID;  //8 bits
        ...
} 
```
- genericHandler
```
 struct DepositRecord { //  now packed together
        uint8   _destinationChainID; // 8 bits
        address _depositer; // 20 bytes
        ...
} 
```
<!-- Issues that this PR will close -->
<!-- 
    NOTE: you must say 'closes #xx' or 'fixes #xx' for EACH issue this closes. 
    eg: 'closes #1 and closes #2'
    See: https://help.github.com/en/articles/closing-issues-using-keywords
-->
#### Closes: #117 
