### PR TITLE
Remove deprecated makefile cmds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,6 @@ install-deps:
 	@echo " > \033[32mInstalling dependencies... \033[0m "
 	./scripts/install_deps.sh
 
-install-cli: compile
-	@echo " > \033[32mInstalling cb-sol-cli... \033[0m "
-	npm link ./cli 
-
 .PHONY: test
 test:
 	@echo " > \033[32mTesting contracts... \033[0m "
@@ -24,10 +20,6 @@ start-ganache:
 start-geth:
 	@echo " > \033[32mStarting geth... \033[0m "
 	./scripts/geth/start_geth.sh
-
-deploy:
-	@echo " > \033[32mDeploying evm contracts... \033[0m "
-	./cli/index.js deploy --url=${URL}
 
 bindings: compile
 	@echo " > \033[32mCreating go bindings for ethereum contracts... \033[0m "


### PR DESCRIPTION
<!--
 Before submitting a PR please ensure all code is commented and all tests are passing. Make sure to review the changes and ensure that only required changes are included (eg. no unnecessary reformatting by your editor)
-->

These have since moved to https://github.com/ChainSafe/chainbridge-deploy/tree/master/cb-sol-cli

<!-- Brief but specific list of changes made, describe the change in functionality rather than the change in code -->
## Changes
- Removes `install-cli` and `deploy`

<!-- Issues that this PR will close -->
<!-- 
    NOTE: you must say 'closes #xx' or 'fixes #xx' for EACH issue this closes. 
    eg: 'closes #1 and closes #2'
    See: https://help.github.com/en/articles/closing-issues-using-keywords
-->
#### Closes: #204 
