### PR TITLE
Passing depositor address to downstream caller

### DIFF
--- a/contracts/TestContracts.sol
+++ b/contracts/TestContracts.sol
@@ -2,32 +2,43 @@ pragma solidity 0.6.4;
 
 contract NoArgument {
     event NoArgumentCalled();
+    event DepositArg(address depositer);
 
-    function noArgument() external {
+    function noArgument(address depositer) external {
         emit NoArgumentCalled();
+        emit DepositArg(depositer);
     }
 }
 
 contract OneArgument {
     event OneArgumentCalled(uint256 indexed argumentOne);
+    event DepositArg(address depositer);
 
-    function oneArgument(uint256 argumentOne) external {
+    function oneArgument(address depositer, bytes calldata metadata) external {
+        (uint256 argumentOne) = abi.decode(metadata, (uint256));
         emit OneArgumentCalled(argumentOne);
+        emit DepositArg(depositer);
     }
 }
 
 contract TwoArguments {
     event TwoArgumentsCalled(address[] argumentOne, bytes4 argumentTwo);
+    event DepositArg(address depositer);
 
-    function twoArguments(address[] calldata argumentOne, bytes4 argumentTwo) external {
+    function twoArguments(address depositer, bytes calldata metadata) external {
+        (address[] memory argumentOne, bytes4 argumentTwo) = abi.decode(metadata, (address[], bytes4));
         emit TwoArgumentsCalled(argumentOne, argumentTwo);
+        emit DepositArg(depositer);
     }
 }
 
 contract ThreeArguments {
     event ThreeArgumentsCalled(string argumentOne, int8 argumentTwo, bool argumentThree);
+    event DepositArg(address depositer);
 
-    function threeArguments(string calldata argumentOne, int8 argumentTwo, bool argumentThree) external {
+    function threeArguments(address depositer, bytes calldata metadata) external {
+        (string memory argumentOne, int8 argumentTwo, bool argumentThree) = abi.decode(metadata, (string, int8, bool));
         emit ThreeArgumentsCalled(argumentOne, argumentTwo, argumentThree);
+        emit DepositArg(depositer);
     }
 }

--- a/contracts/handlers/GenericHandler.sol
+++ b/contracts/handlers/GenericHandler.sol
@@ -150,7 +150,7 @@ contract GenericHandler is IGenericHandler {
 
         bytes4 sig = _contractAddressToDepositFunctionSignature[contractAddress];
         if (sig != bytes4(0)) {
-            bytes memory callData = abi.encodePacked(sig, metadata);
+            bytes memory callData = abi.encodePacked(sig, metadata, abi.encode(depositer));
             (bool success,) = contractAddress.call(callData);
             require(success, "delegatecall to contractAddress failed");
         }

--- a/contracts/handlers/GenericHandler.sol
+++ b/contracts/handlers/GenericHandler.sol
@@ -150,7 +150,7 @@ contract GenericHandler is IGenericHandler {
 
         bytes4 sig = _contractAddressToDepositFunctionSignature[contractAddress];
         if (sig != bytes4(0)) {
-            bytes memory callData = abi.encodePacked(sig, metadata, abi.encode(depositer));
+            bytes memory callData = abi.encodeWithSelector(sig, depositer, metadata);
             (bool success,) = contractAddress.call(callData);
             require(success, "delegatecall to contractAddress failed");
         }

--- a/test/handlers/generic/deposit.js
+++ b/test/handlers/generic/deposit.js
@@ -80,7 +80,7 @@ contract('GenericHandler - [deposit]', async (accounts) => {
             initialContractAddresses,
             initialDepositFunctionSignatures,
             initialExecuteFunctionSignatures);
-        
+
         await Promise.all([
             BridgeInstance.adminSetGenericResource(GenericHandlerInstance.address, initialResourceIDs[0], initialContractAddresses[0], initialDepositFunctionSignatures[0], initialExecuteFunctionSignatures[0]),
             BridgeInstance.adminSetGenericResource(GenericHandlerInstance.address, initialResourceIDs[1], initialContractAddresses[1], initialDepositFunctionSignatures[1], initialExecuteFunctionSignatures[1]),
@@ -88,7 +88,7 @@ contract('GenericHandler - [deposit]', async (accounts) => {
             BridgeInstance.adminSetGenericResource(GenericHandlerInstance.address, initialResourceIDs[3], initialContractAddresses[3], initialDepositFunctionSignatures[3], initialExecuteFunctionSignatures[3]),
             BridgeInstance.adminSetGenericResource(GenericHandlerInstance.address, initialResourceIDs[4], initialContractAddresses[4], initialDepositFunctionSignatures[4], initialExecuteFunctionSignatures[4])
         ]);
-                
+
         depositData = Helpers.createGenericDepositData('0xdeadbeef');
     });
 
@@ -140,6 +140,7 @@ contract('GenericHandler - [deposit]', async (accounts) => {
 
         const internalTx = await TruffleAssert.createTransactionResult(NoArgumentInstance, depositTx.tx);
         TruffleAssert.eventEmitted(internalTx, 'NoArgumentCalled');
+        TruffleAssert.eventEmitted(internalTx, 'DepositArg', event => event.depositer === depositerAddress);
     });
 
     it('oneArgument can be called successfully and depositRecord is created with expected values', async () => {
@@ -150,7 +151,7 @@ contract('GenericHandler - [deposit]', async (accounts) => {
             _depositer: depositerAddress,
             _metaData: argumentOne
         };
-        
+
         const depositTx = await BridgeInstance.deposit(
             chainID,
             initialResourceIDs[2],
@@ -163,6 +164,7 @@ contract('GenericHandler - [deposit]', async (accounts) => {
 
         const internalTx = await TruffleAssert.createTransactionResult(OneArgumentInstance, depositTx.tx);
         TruffleAssert.eventEmitted(internalTx, 'OneArgumentCalled', event => event.argumentOne.toNumber() === argumentOne);
+        TruffleAssert.eventEmitted(internalTx, 'DepositArg', event => event.depositer === depositerAddress);
     });
 
     it('twoArguments can be called successfully and depositRecord is created with expected values', async () => {
@@ -175,7 +177,7 @@ contract('GenericHandler - [deposit]', async (accounts) => {
             _depositer: depositerAddress,
             _metaData: encodedMetaData
         };
-        
+
         const depositTx = await BridgeInstance.deposit(
             chainID,
             initialResourceIDs[3],
@@ -191,6 +193,7 @@ contract('GenericHandler - [deposit]', async (accounts) => {
             return JSON.stringify(event.argumentOne), JSON.stringify(argumentOne) &&
             event.argumentTwo === argumentTwo
         });
+        TruffleAssert.eventEmitted(internalTx, 'DepositArg', event => event.depositer === depositerAddress);
     });
 
     it('threeArguments can be called successfully and depositRecord is created with expected values', async () => {
@@ -204,7 +207,7 @@ contract('GenericHandler - [deposit]', async (accounts) => {
             _depositer: depositerAddress,
             _metaData: encodedMetaData
         };
-        
+
         const depositTx = await BridgeInstance.deposit(
             chainID,
             initialResourceIDs[4],
@@ -220,5 +223,6 @@ contract('GenericHandler - [deposit]', async (accounts) => {
             event.argumentOne === argumentOne &&
             event.argumentTwo.toNumber() === argumentTwo &&
             event.argumentThree === argumentThree);
+        TruffleAssert.eventEmitted(internalTx, 'DepositArg', event => event.depositer === depositerAddress);
     });
 });


### PR DESCRIPTION
## Changes
- GenericHandler passes depositor address to the downstream contract
- Some additional unit tests

#### Closes: #207
