### PR TITLE
Add depositer verification to GenericHandler deposit

### DIFF
--- a/contracts/Bridge.sol
+++ b/contracts/Bridge.sol
@@ -42,7 +42,7 @@ contract Bridge is Pausable, AccessControl, SafeMath {
     // destinationChainID + depositNonce => dataHash => relayerAddress => bool
     mapping(uint72 => mapping(bytes32 => mapping(address => bool))) public _hasVotedOnProposal;
 
-    event RelayerThresholdChanged(uint indexed newThreshold);
+    event RelayerThresholdChanged(uint256 indexed newThreshold);
     event RelayerAdded(address indexed relayer);
     event RelayerRemoved(address indexed relayer);
     event Deposit(
@@ -102,7 +102,7 @@ contract Bridge is Pausable, AccessControl, SafeMath {
         @param initialRelayers Addresses that should be initially granted the relayer role.
         @param initialRelayerThreshold Number of votes needed for a deposit proposal to be considered passed.
      */
-    constructor (uint8 chainID, address[] memory initialRelayers, uint initialRelayerThreshold, uint256 fee, uint256 expiry) public {
+    constructor (uint8 chainID, address[] memory initialRelayers, uint256 initialRelayerThreshold, uint256 fee, uint256 expiry) public {
         _chainID = chainID;
         _relayerThreshold = initialRelayerThreshold;
         _fee = fee;
@@ -110,7 +110,7 @@ contract Bridge is Pausable, AccessControl, SafeMath {
 
         _setupRole(DEFAULT_ADMIN_ROLE, msg.sender);
 
-        for (uint i; i < initialRelayers.length; i++) {
+        for (uint256 i; i < initialRelayers.length; i++) {
             grantRole(RELAYER_ROLE, initialRelayers[i]);
         }
 
@@ -157,7 +157,7 @@ contract Bridge is Pausable, AccessControl, SafeMath {
         @param newThreshold Value {_relayerThreshold} will be changed to.
         @notice Emits {RelayerThresholdChanged} event.
      */
-    function adminChangeRelayerThreshold(uint newThreshold) external onlyAdmin {
+    function adminChangeRelayerThreshold(uint256 newThreshold) external onlyAdmin {
         _relayerThreshold = newThreshold;
         emit RelayerThresholdChanged(newThreshold);
     }
@@ -215,11 +215,12 @@ contract Bridge is Pausable, AccessControl, SafeMath {
         bytes32 resourceID,
         address contractAddress,
         bytes4 depositFunctionSig,
+        uint256 depositFunctionDepositerOffset,
         bytes4 executeFunctionSig
     ) external onlyAdmin {
         _resourceIDToHandlerAddress[resourceID] = handlerAddress;
         IGenericHandler handler = IGenericHandler(handlerAddress);
-        handler.setResource(resourceID, contractAddress, depositFunctionSig, executeFunctionSig);
+        handler.setResource(resourceID, contractAddress, depositFunctionSig, depositFunctionDepositerOffset, executeFunctionSig);
     }
 
     /**
@@ -262,7 +263,7 @@ contract Bridge is Pausable, AccessControl, SafeMath {
         @notice Only callable by admin.
         @param newFee Value {_fee} will be updated to.
      */
-    function adminChangeFee(uint newFee) external onlyAdmin {
+    function adminChangeFee(uint256 newFee) external onlyAdmin {
         require(_fee != newFee, "Current fee is equal to new fee");
         _fee = newFee;
     }
@@ -425,7 +426,7 @@ contract Bridge is Pausable, AccessControl, SafeMath {
         @param amounts Array of amonuts to transfer to {addrs}.
      */
     function transferFunds(address payable[] calldata addrs, uint[] calldata amounts) external onlyAdmin {
-        for (uint i = 0; i < addrs.length; i++) {
+        for (uint256 i = 0; i < addrs.length; i++) {
             addrs[i].transfer(amounts[i]);
         }
     }

--- a/contracts/TestContracts.sol
+++ b/contracts/TestContracts.sol
@@ -31,3 +31,11 @@ contract ThreeArguments {
         emit ThreeArgumentsCalled(argumentOne, argumentTwo, argumentThree);
     }
 }
+
+contract WithDepositer {
+    event WithDepositerCalled(address argumentOne, uint256 argumentTwo);
+
+    function withDepositer(address argumentOne, uint256 argumentTwo) external {
+        emit WithDepositerCalled(argumentOne, argumentTwo);
+    }
+}

--- a/contracts/handlers/GenericHandler.sol
+++ b/contracts/handlers/GenericHandler.sol
@@ -30,6 +30,9 @@ contract GenericHandler is IGenericHandler {
     // contract address => deposit function signature
     mapping (address => bytes4) public _contractAddressToDepositFunctionSignature;
 
+    // contract address => depositer address position offset in the metadata
+    mapping (address => uint256) public _contractAddressToDepositFunctionDepositerOffset;
+
     // contract address => execute proposal function signature
     mapping (address => bytes4) public _contractAddressToExecuteFunctionSignature;
 
@@ -42,7 +45,7 @@ contract GenericHandler is IGenericHandler {
     }
 
     function _onlyBridge() private view {
-         require(msg.sender == _bridgeAddress, "sender must be bridge contract");
+        require(msg.sender == _bridgeAddress, "sender must be bridge contract");
     }
 
     /**
@@ -67,6 +70,7 @@ contract GenericHandler is IGenericHandler {
         bytes32[] memory initialResourceIDs,
         address[] memory initialContractAddresses,
         bytes4[]  memory initialDepositFunctionSignatures,
+        uint256[] memory initialDepositFunctionDepositerOffsets,
         bytes4[]  memory initialExecuteFunctionSignatures
     ) public {
         require(initialResourceIDs.length == initialContractAddresses.length,
@@ -78,6 +82,9 @@ contract GenericHandler is IGenericHandler {
         require(initialDepositFunctionSignatures.length == initialExecuteFunctionSignatures.length,
             "provided deposit and execute function signatures len mismatch");
 
+        require(initialDepositFunctionDepositerOffsets.length == initialExecuteFunctionSignatures.length,
+            "provided depositer offsets and function signatures len mismatch");
+
         _bridgeAddress = bridgeAddress;
 
         for (uint256 i = 0; i < initialResourceIDs.length; i++) {
@@ -85,6 +92,7 @@ contract GenericHandler is IGenericHandler {
                 initialResourceIDs[i],
                 initialContractAddresses[i],
                 initialDepositFunctionSignatures[i],
+                initialDepositFunctionDepositerOffsets[i],
                 initialExecuteFunctionSignatures[i]);
         }
     }
@@ -108,28 +116,31 @@ contract GenericHandler is IGenericHandler {
         then sets {_resourceIDToContractAddress} with {contractAddress},
         {_contractAddressToResourceID} with {resourceID},
         {_contractAddressToDepositFunctionSignature} with {depositFunctionSig},
+        {_contractAddressToDepositFunctionDepositerOffset} with {depositFunctionDepositerOffset},
         {_contractAddressToExecuteFunctionSignature} with {executeFunctionSig},
         and {_contractWhitelist} to true for {contractAddress}.
         @param resourceID ResourceID to be used when making deposits.
         @param contractAddress Address of contract to be called when a deposit is made and a deposited is executed.
         @param depositFunctionSig Function signature of method to be called in {contractAddress} when a deposit is made.
+        @param depositFunctionDepositerOffset Depositer address position offset in the metadata, in bytes.
         @param executeFunctionSig Function signature of method to be called in {contractAddress} when a deposit is executed.
      */
     function setResource(
         bytes32 resourceID,
         address contractAddress,
         bytes4 depositFunctionSig,
+        uint256 depositFunctionDepositerOffset,
         bytes4 executeFunctionSig
     ) external onlyBridge override {
 
-        _setResource(resourceID, contractAddress, depositFunctionSig, executeFunctionSig);
+        _setResource(resourceID, contractAddress, depositFunctionSig, depositFunctionDepositerOffset, executeFunctionSig);
     }
 
     /**
         @notice A deposit is initiatied by making a deposit in the Bridge contract.
         @param destinationChainID Chain ID deposit is expected to be bridged to.
         @param depositNonce This value is generated as an ID by the Bridge contract.
-        @param depositer Address of account making the deposit in the Bridge contract.
+        @param depositer Address of the account making deposit in the Bridge contract.
         @param data Consists of: {resourceID}, {lenMetaData}, and {metaData} all padded to 32 bytes.
         @notice Data passed into the function should be constructed as follows:
         len(data)                              uint256     bytes  0  - 32
@@ -139,20 +150,32 @@ contract GenericHandler is IGenericHandler {
         {metaData} is expected to consist of needed function arguments.
      */
     function deposit(bytes32 resourceID, uint8 destinationChainID, uint64 depositNonce, address depositer, bytes calldata data) external onlyBridge {
-        uint      lenMetadata;
+        uint256      lenMetadata;
         bytes memory metadata;
 
-        lenMetadata = abi.decode(data, (uint));
+        lenMetadata = abi.decode(data, (uint256));
         metadata = bytes(data[32:32 + lenMetadata]);
 
         address contractAddress = _resourceIDToContractAddress[resourceID];
+        uint256 depositerOffset = _contractAddressToDepositFunctionDepositerOffset[contractAddress];
+        if (depositerOffset > 0) {
+            uint256 metadataDepositer;
+            // Skipping 32 bytes of length prefix and depositerOffset bytes.
+            assembly {
+                metadataDepositer := mload(add(add(metadata, 32), depositerOffset))
+            }
+            // metadataDepositer contains 0xdepositerAddressdepositerAddressdeposite************************
+            // Shift it 12 bytes right:   0x000000000000000000000000depositerAddressdepositerAddressdeposite
+            require(depositer == address(metadataDepositer >> 96), 'incorrect depositer in the data');
+        }
+
         require(_contractWhitelist[contractAddress], "provided contractAddress is not whitelisted");
 
         bytes4 sig = _contractAddressToDepositFunctionSignature[contractAddress];
         if (sig != bytes4(0)) {
             bytes memory callData = abi.encodePacked(sig, metadata);
             (bool success,) = contractAddress.call(callData);
-            require(success, "delegatecall to contractAddress failed");
+            require(success, "call to contractAddress failed");
         }
 
         _depositRecords[destinationChainID][depositNonce] = DepositRecord(
@@ -174,10 +197,10 @@ contract GenericHandler is IGenericHandler {
         {metaData} is expected to consist of needed function arguments.
      */
     function executeProposal(bytes32 resourceID, bytes calldata data) external onlyBridge {
-        uint      lenMetadata;
+        uint256      lenMetadata;
         bytes memory metaData;
 
-        lenMetadata = abi.decode(data, (uint));
+        lenMetadata = abi.decode(data, (uint256));
         metaData = bytes(data[32:32 + lenMetadata]);
 
         address contractAddress = _resourceIDToContractAddress[resourceID];
@@ -195,11 +218,13 @@ contract GenericHandler is IGenericHandler {
         bytes32 resourceID,
         address contractAddress,
         bytes4 depositFunctionSig,
+        uint256 depositFunctionDepositerOffset,
         bytes4 executeFunctionSig
     ) internal {
         _resourceIDToContractAddress[resourceID] = contractAddress;
         _contractAddressToResourceID[contractAddress] = resourceID;
         _contractAddressToDepositFunctionSignature[contractAddress] = depositFunctionSig;
+        _contractAddressToDepositFunctionDepositerOffset[contractAddress] = depositFunctionDepositerOffset;
         _contractAddressToExecuteFunctionSignature[contractAddress] = executeFunctionSig;
 
         _contractWhitelist[contractAddress] = true;

--- a/contracts/handlers/GenericHandler.sol
+++ b/contracts/handlers/GenericHandler.sol
@@ -56,6 +56,8 @@ contract GenericHandler is IGenericHandler {
         called to perform deposit and execution calls.
         @param initialDepositFunctionSignatures These are the function signatures {initialContractAddresses} will point to,
         and are the function that will be called when executing {deposit}
+        @param initialDepositFunctionDepositerOffsets These are the offsets of depositer positions, inside of metadata used to call
+        {initialContractAddresses} when executing {deposit}
         @param initialExecuteFunctionSignatures These are the function signatures {initialContractAddresses} will point to,
         and are the function that will be called when executing {executeProposal}
 

--- a/contracts/interfaces/IGenericHandler.sol
+++ b/contracts/interfaces/IGenericHandler.sol
@@ -10,7 +10,13 @@ interface IGenericHandler {
         @param resourceID ResourceID to be used when making deposits.
         @param contractAddress Address of contract to be called when a deposit is made and a deposited is executed.
         @param depositFunctionSig Function signature of method to be called in {contractAddress} when a deposit is made.
+        @param depositFunctionDepositerOffset Depositer address position offset in the metadata, in bytes.
         @param executeFunctionSig Function signature of method to be called in {contractAddress} when a deposit is executed.
      */
-    function setResource(bytes32 resourceID, address contractAddress, bytes4 depositFunctionSig, bytes4 executeFunctionSig) external;
+    function setResource(
+        bytes32 resourceID,
+        address contractAddress,
+        bytes4 depositFunctionSig,
+        uint depositFunctionDepositerOffset,
+        bytes4 executeFunctionSig) external;
 }

--- a/test/contractBridge/admin.js
+++ b/test/contractBridge/admin.js
@@ -139,15 +139,15 @@ contract('Bridge - [admin]', async accounts => {
     it('Should set a Generic Resource ID and contract address', async () => {
         const CentrifugeAssetInstance = await CentrifugeAssetContract.new();
         const resourceID = Helpers.createResourceID(CentrifugeAssetInstance.address, chainID);
-        const GenericHandlerInstance = await GenericHandlerContract.new(BridgeInstance.address, [], [], [], []);
+        const GenericHandlerInstance = await GenericHandlerContract.new(BridgeInstance.address, [], [], [], [], []);
 
-        await TruffleAssert.passes(BridgeInstance.adminSetGenericResource(GenericHandlerInstance.address, resourceID, CentrifugeAssetInstance.address, '0x00000000', '0x00000000'));
+        await TruffleAssert.passes(BridgeInstance.adminSetGenericResource(GenericHandlerInstance.address, resourceID, CentrifugeAssetInstance.address, '0x00000000', 0, '0x00000000'));
         assert.equal(await GenericHandlerInstance._resourceIDToContractAddress.call(resourceID), CentrifugeAssetInstance.address);
         assert.equal(await GenericHandlerInstance._contractAddressToResourceID.call(CentrifugeAssetInstance.address), resourceID.toLowerCase());
     });
 
     it('Should require admin role to set a Generic Resource ID and contract address', async () => {
-        await assertOnlyAdmin(BridgeInstance.adminSetGenericResource, someAddress, bytes32, someAddress, '0x00000000', '0x00000000');
+        await assertOnlyAdmin(BridgeInstance.adminSetGenericResource, someAddress, bytes32, someAddress, '0x00000000', 0, '0x00000000');
     });
 
     // Set burnable

--- a/test/contractBridge/depositGeneric.js
+++ b/test/contractBridge/depositGeneric.js
@@ -22,6 +22,7 @@ contract('Bridge - [deposit - Generic]', async () => {
     let initialResourceIDs;
     let initialContractAddresses;
     let initialDepositFunctionSignatures;
+    let initialDepositFunctionDepositerOffsets;
     let initialExecuteFunctionSignatures;
 
     beforeEach(async () => {
@@ -34,6 +35,7 @@ contract('Bridge - [deposit - Generic]', async () => {
         initialResourceIDs = [resourceID];
         initialContractAddresses = [CentrifugeAssetInstance.address];
         initialDepositFunctionSignatures = [Helpers.blankFunctionSig];
+        initialDepositFunctionDepositerOffsets = [Helpers.blankFunctionDepositerOffset];
         initialExecuteFunctionSignatures = [Helpers.getFunctionSignature(CentrifugeAssetInstance, 'store')];
 
         GenericHandlerInstance = await GenericHandlerContract.new(
@@ -41,9 +43,10 @@ contract('Bridge - [deposit - Generic]', async () => {
             initialResourceIDs,
             initialContractAddresses,
             initialDepositFunctionSignatures,
+            initialDepositFunctionDepositerOffsets,
             initialExecuteFunctionSignatures);
             
-        await BridgeInstance.adminSetGenericResource(GenericHandlerInstance.address, resourceID,  initialContractAddresses[0], initialDepositFunctionSignatures[0], initialExecuteFunctionSignatures[0]);
+        await BridgeInstance.adminSetGenericResource(GenericHandlerInstance.address, resourceID,  initialContractAddresses[0], initialDepositFunctionSignatures[0], initialDepositFunctionDepositerOffsets[0], initialExecuteFunctionSignatures[0]);
 
         depositData = Helpers.createGenericDepositData('0xdeadbeef');
     });

--- a/test/contractBridge/fee.js
+++ b/test/contractBridge/fee.js
@@ -16,6 +16,7 @@ contract('Bridge - [fee]', async (accounts) => {
     const originChainID = 1;
     const destinationChainID = 2;
     const blankFunctionSig = '0x00000000';
+    const blankFunctionDepositerOffset = 0;
     const relayer = accounts[0];
 
     let BridgeInstance;
@@ -25,6 +26,7 @@ contract('Bridge - [fee]', async (accounts) => {
     let initialResourceIDs;
     let initialContractAddresses;
     let initialDepositFunctionSignatures;
+    let initialDepositFunctionDepositerOffsets;
     let initialExecuteFunctionSignatures;
 
     beforeEach(async () => {
@@ -37,6 +39,7 @@ contract('Bridge - [fee]', async (accounts) => {
         initialResourceIDs = [resourceID];
         initialContractAddresses = [CentrifugeAssetInstance.address];
         initialDepositFunctionSignatures = [blankFunctionSig];
+        initialDepositFunctionDepositerOffsets = [blankFunctionDepositerOffset];
         initialExecuteFunctionSignatures = [blankFunctionSig];
 
         GenericHandlerInstance = await GenericHandlerContract.new(
@@ -44,9 +47,10 @@ contract('Bridge - [fee]', async (accounts) => {
             initialResourceIDs,
             initialContractAddresses,
             initialDepositFunctionSignatures,
+            initialDepositFunctionDepositerOffsets,
             initialExecuteFunctionSignatures);
 
-        await BridgeInstance.adminSetGenericResource(GenericHandlerInstance.address, resourceID,  initialContractAddresses[0], initialDepositFunctionSignatures[0], initialExecuteFunctionSignatures[0]);
+        await BridgeInstance.adminSetGenericResource(GenericHandlerInstance.address, resourceID,  initialContractAddresses[0], initialDepositFunctionSignatures[0], initialDepositFunctionDepositerOffsets[0], initialExecuteFunctionSignatures[0]);
             
         depositData = Helpers.createGenericDepositData('0xdeadbeef');
     });

--- a/test/gasBenchmarks/deployments.js
+++ b/test/gasBenchmarks/deployments.js
@@ -18,6 +18,7 @@ contract('Gas Benchmark - [contract deployments]', async () => {
     const initialContractAddresses = [];
     const burnableContractAddresses = [];
     const initialDepositFunctionSignatures = [];
+    const initialDepositFunctionDepositerOffsets = [];
     const initialExecuteFunctionSignatures = [];
     const centrifugeAssetMinCount = 1;
     const gasBenchmarks = [];
@@ -30,7 +31,7 @@ contract('Gas Benchmark - [contract deployments]', async () => {
             await Promise.all([
                 ERC20HandlerContract.new(BridgeInstance.address, initialResourceIDs, initialContractAddresses, burnableContractAddresses),
                 ERC721HandlerContract.new(BridgeInstance.address, initialResourceIDs, initialContractAddresses, burnableContractAddresses),
-                GenericHandlerContract.new(BridgeInstance.address, initialResourceIDs, initialContractAddresses, initialDepositFunctionSignatures, initialExecuteFunctionSignatures),
+                GenericHandlerContract.new(BridgeInstance.address, initialResourceIDs, initialContractAddresses, initialDepositFunctionSignatures, initialDepositFunctionDepositerOffsets, initialExecuteFunctionSignatures),
                 CentrifugeAssetContract.new(centrifugeAssetMinCount),
                 HandlerHelpersContract.new(),
                 ERC20SafeContract.new(),

--- a/test/gasBenchmarks/deposits.js
+++ b/test/gasBenchmarks/deposits.js
@@ -92,6 +92,12 @@ contract('Gas Benchmark - [Deposits]', async (accounts) => {
             Helpers.getFunctionSignature(OneArgumentInstance, 'oneArgument'),
             Helpers.getFunctionSignature(TwoArgumentsInstance, 'twoArguments'),
             Helpers.getFunctionSignature(ThreeArgumentsInstance, 'threeArguments')];
+        const genericInitialDepositFunctionDepositerOffsets = [
+            Helpers.blankFunctionDepositerOffset,
+            Helpers.blankFunctionDepositerOffset,
+            Helpers.blankFunctionDepositerOffset,
+            Helpers.blankFunctionDepositerOffset,
+            Helpers.blankFunctionDepositerOffset];
         const genericInitialExecuteFunctionSignatures = [
             Helpers.getFunctionSignature(CentrifugeAssetInstance, 'store'),
             Helpers.blankFunctionSig,
@@ -104,7 +110,7 @@ contract('Gas Benchmark - [Deposits]', async (accounts) => {
             ERC20MintableInstance.mint(depositerAddress, erc20TokenAmount),
             ERC721HandlerContract.new(BridgeInstance.address, erc721InitialResourceIDs, erc721InitialContractAddresses, erc721BurnableContractAddresses).then(instance => ERC721HandlerInstance = instance),
             ERC721MintableInstance.mint(depositerAddress, erc721TokenID, ""),
-            GenericHandlerInstance = await GenericHandlerContract.new(BridgeInstance.address, genericInitialResourceIDs, genericInitialContractAddresses, genericInitialDepositFunctionSignatures, genericInitialExecuteFunctionSignatures)
+            GenericHandlerInstance = await GenericHandlerContract.new(BridgeInstance.address, genericInitialResourceIDs, genericInitialContractAddresses, genericInitialDepositFunctionSignatures, genericInitialDepositFunctionDepositerOffsets, genericInitialExecuteFunctionSignatures)
         ]);
 
         await Promise.all([
@@ -112,11 +118,11 @@ contract('Gas Benchmark - [Deposits]', async (accounts) => {
             ERC721MintableInstance.approve(ERC721HandlerInstance.address, erc721TokenID, { from: depositerAddress }),
             BridgeInstance.adminSetResource(ERC20HandlerInstance.address, erc20ResourceID, ERC20MintableInstance.address),
             BridgeInstance.adminSetResource(ERC721HandlerInstance.address, erc721ResourceID, ERC721MintableInstance.address),
-            BridgeInstance.adminSetGenericResource(GenericHandlerInstance.address, centrifugeAssetResourceID, genericInitialContractAddresses[0], genericInitialDepositFunctionSignatures[0], genericInitialExecuteFunctionSignatures[0]),
-            BridgeInstance.adminSetGenericResource(GenericHandlerInstance.address, noArgumentResourceID, genericInitialContractAddresses[1], genericInitialDepositFunctionSignatures[1], genericInitialExecuteFunctionSignatures[1]),
-            BridgeInstance.adminSetGenericResource(GenericHandlerInstance.address, oneArgumentResourceID, genericInitialContractAddresses[2], genericInitialDepositFunctionSignatures[2], genericInitialExecuteFunctionSignatures[2]),
-            BridgeInstance.adminSetGenericResource(GenericHandlerInstance.address, twoArgumentsResourceID, genericInitialContractAddresses[3], genericInitialDepositFunctionSignatures[3], genericInitialExecuteFunctionSignatures[3]),
-            BridgeInstance.adminSetGenericResource(GenericHandlerInstance.address, threeArgumentsResourceID, genericInitialContractAddresses[4], genericInitialDepositFunctionSignatures[4], genericInitialExecuteFunctionSignatures[4])
+            BridgeInstance.adminSetGenericResource(GenericHandlerInstance.address, centrifugeAssetResourceID, genericInitialContractAddresses[0], genericInitialDepositFunctionSignatures[0], genericInitialDepositFunctionDepositerOffsets[0], genericInitialExecuteFunctionSignatures[0]),
+            BridgeInstance.adminSetGenericResource(GenericHandlerInstance.address, noArgumentResourceID, genericInitialContractAddresses[1], genericInitialDepositFunctionSignatures[1], genericInitialDepositFunctionDepositerOffsets[1], genericInitialExecuteFunctionSignatures[1]),
+            BridgeInstance.adminSetGenericResource(GenericHandlerInstance.address, oneArgumentResourceID, genericInitialContractAddresses[2], genericInitialDepositFunctionSignatures[2], genericInitialDepositFunctionDepositerOffsets[2], genericInitialExecuteFunctionSignatures[2]),
+            BridgeInstance.adminSetGenericResource(GenericHandlerInstance.address, twoArgumentsResourceID, genericInitialContractAddresses[3], genericInitialDepositFunctionSignatures[3], genericInitialDepositFunctionDepositerOffsets[3], genericInitialExecuteFunctionSignatures[3]),
+            BridgeInstance.adminSetGenericResource(GenericHandlerInstance.address, threeArgumentsResourceID, genericInitialContractAddresses[4], genericInitialDepositFunctionSignatures[4], genericInitialDepositFunctionDepositerOffsets[4], genericInitialExecuteFunctionSignatures[4])
         ]);
     });
 

--- a/test/gasBenchmarks/executeProposal.js
+++ b/test/gasBenchmarks/executeProposal.js
@@ -100,6 +100,12 @@ contract('Gas Benchmark - [Execute Proposal]', async (accounts) => {
             Helpers.getFunctionSignature(OneArgumentInstance, 'oneArgument'),
             Helpers.getFunctionSignature(TwoArgumentsInstance, 'twoArguments'),
             Helpers.getFunctionSignature(ThreeArgumentsInstance, 'threeArguments')];
+        const genericInitialDepositFunctionDepositerOffsets = [
+            Helpers.blankFunctionDepositerOffset,
+            Helpers.blankFunctionDepositerOffset,
+            Helpers.blankFunctionDepositerOffset,
+            Helpers.blankFunctionDepositerOffset,
+            Helpers.blankFunctionDepositerOffset];
         const genericInitialExecuteFunctionSignatures = [
             Helpers.getFunctionSignature(CentrifugeAssetInstance, 'store'),
             Helpers.blankFunctionSig,
@@ -112,7 +118,7 @@ contract('Gas Benchmark - [Execute Proposal]', async (accounts) => {
             ERC20MintableInstance.mint(depositerAddress, erc20TokenAmount),
             ERC721HandlerContract.new(BridgeInstance.address, erc721InitialResourceIDs, erc721InitialContractAddresses, erc721BurnableContractAddresses).then(instance => ERC721HandlerInstance = instance),
             ERC721MintableInstance.mint(depositerAddress, erc721TokenID, ""),
-            GenericHandlerInstance = await GenericHandlerContract.new(BridgeInstance.address, genericInitialResourceIDs, genericInitialContractAddresses, genericInitialDepositFunctionSignatures, genericInitialExecuteFunctionSignatures)
+            GenericHandlerInstance = await GenericHandlerContract.new(BridgeInstance.address, genericInitialResourceIDs, genericInitialContractAddresses, genericInitialDepositFunctionSignatures, genericInitialDepositFunctionDepositerOffsets, genericInitialExecuteFunctionSignatures)
         ]);
 
         await Promise.all([
@@ -120,11 +126,11 @@ contract('Gas Benchmark - [Execute Proposal]', async (accounts) => {
             ERC721MintableInstance.approve(ERC721HandlerInstance.address, erc721TokenID, { from: depositerAddress }),
             BridgeInstance.adminSetResource(ERC20HandlerInstance.address, erc20ResourceID, ERC20MintableInstance.address),
             BridgeInstance.adminSetResource(ERC721HandlerInstance.address, erc721ResourceID, ERC721MintableInstance.address),
-            BridgeInstance.adminSetGenericResource(GenericHandlerInstance.address, centrifugeAssetResourceID, genericInitialContractAddresses[0], genericInitialDepositFunctionSignatures[0], genericInitialExecuteFunctionSignatures[0]),
-            BridgeInstance.adminSetGenericResource(GenericHandlerInstance.address, noArgumentResourceID, genericInitialContractAddresses[1], genericInitialDepositFunctionSignatures[1], genericInitialExecuteFunctionSignatures[1]),
-            BridgeInstance.adminSetGenericResource(GenericHandlerInstance.address, oneArgumentResourceID, genericInitialContractAddresses[2], genericInitialDepositFunctionSignatures[2], genericInitialExecuteFunctionSignatures[2]),
-            BridgeInstance.adminSetGenericResource(GenericHandlerInstance.address, twoArgumentsResourceID, genericInitialContractAddresses[3], genericInitialDepositFunctionSignatures[3], genericInitialExecuteFunctionSignatures[3]),
-            BridgeInstance.adminSetGenericResource(GenericHandlerInstance.address, threeArgumentsResourceID, genericInitialContractAddresses[4], genericInitialDepositFunctionSignatures[4], genericInitialExecuteFunctionSignatures[4])
+            BridgeInstance.adminSetGenericResource(GenericHandlerInstance.address, centrifugeAssetResourceID, genericInitialContractAddresses[0], genericInitialDepositFunctionSignatures[0], genericInitialDepositFunctionDepositerOffsets[0], genericInitialExecuteFunctionSignatures[0]),
+            BridgeInstance.adminSetGenericResource(GenericHandlerInstance.address, noArgumentResourceID, genericInitialContractAddresses[1], genericInitialDepositFunctionSignatures[1], genericInitialDepositFunctionDepositerOffsets[1], genericInitialExecuteFunctionSignatures[1]),
+            BridgeInstance.adminSetGenericResource(GenericHandlerInstance.address, oneArgumentResourceID, genericInitialContractAddresses[2], genericInitialDepositFunctionSignatures[2], genericInitialDepositFunctionDepositerOffsets[2], genericInitialExecuteFunctionSignatures[2]),
+            BridgeInstance.adminSetGenericResource(GenericHandlerInstance.address, twoArgumentsResourceID, genericInitialContractAddresses[3], genericInitialDepositFunctionSignatures[3], genericInitialDepositFunctionDepositerOffsets[3], genericInitialExecuteFunctionSignatures[3]),
+            BridgeInstance.adminSetGenericResource(GenericHandlerInstance.address, threeArgumentsResourceID, genericInitialContractAddresses[4], genericInitialDepositFunctionSignatures[4], genericInitialDepositFunctionDepositerOffsets[4], genericInitialExecuteFunctionSignatures[4])
         ]);
     });
 

--- a/test/handlers/generic/constructor.js
+++ b/test/handlers/generic/constructor.js
@@ -17,6 +17,7 @@ contract('GenericHandler - [constructor]', async () => {
     const chainID = 1;
     const centrifugeAssetMinCount = 1;
     const blankFunctionSig = '0x00000000';
+    const blankFunctionDepositerOffset = 0;
     const centrifugeAssetStoreFuncSig = 'store(bytes32)';
 
     let BridgeInstance;
@@ -26,6 +27,7 @@ contract('GenericHandler - [constructor]', async () => {
     let initialResourceIDs;
     let initialContractAddresses;
     let initialDepositFunctionSignatures;
+    let initialDepositFunctionDepositerOffsets;
     let initialExecuteFunctionSignatures;
 
     beforeEach(async () => {
@@ -46,6 +48,7 @@ contract('GenericHandler - [constructor]', async () => {
         const executeProposalFuncSig = Ethers.utils.keccak256(Ethers.utils.hexlify(Ethers.utils.toUtf8Bytes(centrifugeAssetStoreFuncSig))).substr(0, 10);
 
         initialDepositFunctionSignatures = [blankFunctionSig, blankFunctionSig, blankFunctionSig];
+        initialDepositFunctionDepositerOffsets = [blankFunctionDepositerOffset, blankFunctionDepositerOffset, blankFunctionDepositerOffset];
         initialExecuteFunctionSignatures = [executeProposalFuncSig, executeProposalFuncSig, executeProposalFuncSig];
     });
 
@@ -56,6 +59,7 @@ contract('GenericHandler - [constructor]', async () => {
                 initialResourceIDs,
                 initialContractAddresses,
                 initialDepositFunctionSignatures,
+                initialDepositFunctionDepositerOffsets,
                 initialExecuteFunctionSignatures));
     });
 
@@ -66,6 +70,7 @@ contract('GenericHandler - [constructor]', async () => {
                 [],
                 initialContractAddresses,
                 initialDepositFunctionSignatures,
+                initialDepositFunctionDepositerOffsets,
                 initialExecuteFunctionSignatures),
                 "initialResourceIDs and initialContractAddresses len mismatch");
     });
@@ -77,8 +82,21 @@ contract('GenericHandler - [constructor]', async () => {
                 initialResourceIDs,
                 initialContractAddresses,
                 [],
+                initialDepositFunctionDepositerOffsets,
                 initialExecuteFunctionSignatures),
-                "provided contract addresses and function signatures len mismatch.");
+                "provided contract addresses and function signatures len mismatch");
+    });
+
+    it('should revert because provided contract addresses and function signatures len mismatch.', async () => {
+        await TruffleAssert.reverts(
+            GenericHandlerContract.new(
+                BridgeInstance.address,
+                initialResourceIDs,
+                initialContractAddresses,
+                initialDepositFunctionSignatures,
+                [],
+                initialExecuteFunctionSignatures),
+                "provided depositer offsets and function signatures len mismatch");
     });
 
     it('should revert because provided deposit and execute function signatures len mismatch', async () => {
@@ -88,6 +106,7 @@ contract('GenericHandler - [constructor]', async () => {
                 initialResourceIDs,
                 initialContractAddresses,
                 initialDepositFunctionSignatures,
+                initialDepositFunctionDepositerOffsets,
                 []),
                 "provided deposit and execute function signatures len mismatch");
     });
@@ -98,6 +117,7 @@ contract('GenericHandler - [constructor]', async () => {
             initialResourceIDs,
             initialContractAddresses,
             initialDepositFunctionSignatures,
+            initialDepositFunctionDepositerOffsets,
             initialExecuteFunctionSignatures);
         
         for (let i = 0; i < initialResourceIDs.length; i++) {
@@ -109,6 +129,9 @@ contract('GenericHandler - [constructor]', async () => {
 
             const retrievedDepositFunctionSig = await GenericHandlerInstance._contractAddressToDepositFunctionSignature.call(initialContractAddresses[i]);
             assert.strictEqual(initialDepositFunctionSignatures[i].toLowerCase(), retrievedDepositFunctionSig.toLowerCase());
+
+            const retrievedDepositFunctionDepositerOffset = await GenericHandlerInstance._contractAddressToDepositFunctionDepositerOffset.call(initialContractAddresses[i]);
+            assert.strictEqual(initialDepositFunctionDepositerOffsets[i], retrievedDepositFunctionDepositerOffset.toNumber());
 
             const retrievedExecuteFunctionSig = await GenericHandlerInstance._contractAddressToExecuteFunctionSignature.call(initialContractAddresses[i]);
             assert.strictEqual(initialExecuteFunctionSignatures[i].toLowerCase(), retrievedExecuteFunctionSig.toLowerCase());

--- a/test/handlers/generic/deposit.js
+++ b/test/handlers/generic/deposit.js
@@ -14,6 +14,7 @@ const NoArgumentContract = artifacts.require("NoArgument");
 const OneArgumentContract = artifacts.require("OneArgument");
 const TwoArgumentsContract = artifacts.require("TwoArguments");
 const ThreeArgumentsContract = artifacts.require("ThreeArguments");
+const WithDepositerContract = artifacts.require("WithDepositer");
 
 contract('GenericHandler - [deposit]', async (accounts) => {
     const relayerThreshold = 2;
@@ -28,10 +29,12 @@ contract('GenericHandler - [deposit]', async (accounts) => {
     let OneArgumentInstance;
     let TwoArgumentsInstance;
     let ThreeArgumentsInstance;
+    let WithDepositerInstance;
 
     let initialResourceIDs;
     let initialContractAddresses;
     let initialDepositFunctionSignatures;
+    let initialDepositFunctionDepositerOffsets;
     let initialExecuteFunctionSignatures;
     let GenericHandlerInstance;
     let depositData
@@ -43,7 +46,8 @@ contract('GenericHandler - [deposit]', async (accounts) => {
             NoArgumentContract.new().then(instance => NoArgumentInstance = instance),
             OneArgumentContract.new().then(instance => OneArgumentInstance = instance),
             TwoArgumentsContract.new().then(instance => TwoArgumentsInstance = instance),
-            ThreeArgumentsContract.new().then(instance => ThreeArgumentsInstance = instance)
+            ThreeArgumentsContract.new().then(instance => ThreeArgumentsInstance = instance),
+            WithDepositerContract.new().then(instance => WithDepositerInstance = instance),
         ]);
 
         initialResourceIDs = [
@@ -52,26 +56,39 @@ contract('GenericHandler - [deposit]', async (accounts) => {
             Helpers.createResourceID(OneArgumentInstance.address, chainID),
             Helpers.createResourceID(TwoArgumentsInstance.address, chainID),
             Helpers.createResourceID(ThreeArgumentsInstance.address, chainID),
+            Helpers.createResourceID(WithDepositerInstance.address, chainID),
         ];
         initialContractAddresses = [
             CentrifugeAssetInstance.address,
             NoArgumentInstance.address,
             OneArgumentInstance.address,
             TwoArgumentsInstance.address,
-            ThreeArgumentsInstance.address];
+            ThreeArgumentsInstance.address,
+            WithDepositerInstance.address,
+        ];
         initialDepositFunctionSignatures = [
             Helpers.blankFunctionSig,
             Helpers.getFunctionSignature(NoArgumentInstance, 'noArgument'),
             Helpers.getFunctionSignature(OneArgumentInstance, 'oneArgument'),
             Helpers.getFunctionSignature(TwoArgumentsInstance, 'twoArguments'),
-            Helpers.getFunctionSignature(ThreeArgumentsInstance, 'threeArguments')
+            Helpers.getFunctionSignature(ThreeArgumentsInstance, 'threeArguments'),
+            Helpers.getFunctionSignature(WithDepositerInstance, 'withDepositer'),
+        ];
+        initialDepositFunctionDepositerOffsets = [
+            Helpers.blankFunctionDepositerOffset,
+            Helpers.blankFunctionDepositerOffset,
+            Helpers.blankFunctionDepositerOffset,
+            Helpers.blankFunctionDepositerOffset,
+            Helpers.blankFunctionDepositerOffset,
+            12,
         ];
         initialExecuteFunctionSignatures = [
             Helpers.getFunctionSignature(CentrifugeAssetInstance, 'store'),
             Helpers.blankFunctionSig,
             Helpers.blankFunctionSig,
             Helpers.blankFunctionSig,
-            Helpers.blankFunctionSig
+            Helpers.blankFunctionSig,
+            Helpers.blankFunctionSig,
         ];
 
         GenericHandlerInstance = await GenericHandlerContract.new(
@@ -79,14 +96,16 @@ contract('GenericHandler - [deposit]', async (accounts) => {
             initialResourceIDs,
             initialContractAddresses,
             initialDepositFunctionSignatures,
+            initialDepositFunctionDepositerOffsets,
             initialExecuteFunctionSignatures);
         
         await Promise.all([
-            BridgeInstance.adminSetGenericResource(GenericHandlerInstance.address, initialResourceIDs[0], initialContractAddresses[0], initialDepositFunctionSignatures[0], initialExecuteFunctionSignatures[0]),
-            BridgeInstance.adminSetGenericResource(GenericHandlerInstance.address, initialResourceIDs[1], initialContractAddresses[1], initialDepositFunctionSignatures[1], initialExecuteFunctionSignatures[1]),
-            BridgeInstance.adminSetGenericResource(GenericHandlerInstance.address, initialResourceIDs[2], initialContractAddresses[2], initialDepositFunctionSignatures[2], initialExecuteFunctionSignatures[2]),
-            BridgeInstance.adminSetGenericResource(GenericHandlerInstance.address, initialResourceIDs[3], initialContractAddresses[3], initialDepositFunctionSignatures[3], initialExecuteFunctionSignatures[3]),
-            BridgeInstance.adminSetGenericResource(GenericHandlerInstance.address, initialResourceIDs[4], initialContractAddresses[4], initialDepositFunctionSignatures[4], initialExecuteFunctionSignatures[4])
+            BridgeInstance.adminSetGenericResource(GenericHandlerInstance.address, initialResourceIDs[0], initialContractAddresses[0], initialDepositFunctionSignatures[0], initialDepositFunctionDepositerOffsets[0], initialExecuteFunctionSignatures[0]),
+            BridgeInstance.adminSetGenericResource(GenericHandlerInstance.address, initialResourceIDs[1], initialContractAddresses[1], initialDepositFunctionSignatures[1], initialDepositFunctionDepositerOffsets[1], initialExecuteFunctionSignatures[1]),
+            BridgeInstance.adminSetGenericResource(GenericHandlerInstance.address, initialResourceIDs[2], initialContractAddresses[2], initialDepositFunctionSignatures[2], initialDepositFunctionDepositerOffsets[2], initialExecuteFunctionSignatures[2]),
+            BridgeInstance.adminSetGenericResource(GenericHandlerInstance.address, initialResourceIDs[3], initialContractAddresses[3], initialDepositFunctionSignatures[3], initialDepositFunctionDepositerOffsets[3], initialExecuteFunctionSignatures[3]),
+            BridgeInstance.adminSetGenericResource(GenericHandlerInstance.address, initialResourceIDs[4], initialContractAddresses[4], initialDepositFunctionSignatures[4], initialDepositFunctionDepositerOffsets[4], initialExecuteFunctionSignatures[4]),
+            BridgeInstance.adminSetGenericResource(GenericHandlerInstance.address, initialResourceIDs[5], initialContractAddresses[5], initialDepositFunctionSignatures[5], initialDepositFunctionDepositerOffsets[5], initialExecuteFunctionSignatures[5])
         ]);
                 
         depositData = Helpers.createGenericDepositData('0xdeadbeef');
@@ -193,21 +212,20 @@ contract('GenericHandler - [deposit]', async (accounts) => {
         });
     });
 
-    it('threeArguments can be called successfully and depositRecord is created with expected values', async () => {
-        const argumentOne = 'soylentGreenIsPeople';
-        const argumentTwo = -42;
-        const argumentThree = true;
-        const encodedMetaData = Helpers.abiEncode(['string','int8','bool'], [argumentOne, argumentTwo, argumentThree]);
+    it('withDepositer can be called successfully and depositRecord is created with expected values', async () => {
+        const argumentOne = depositerAddress;
+        const argumentTwo = 100;
+        const encodedMetaData = Helpers.abiEncode(['address','uint256'], [argumentOne, argumentTwo]);
         const expectedDepositRecord = {
             _destinationChainID: chainID,
-            _resourceID: initialResourceIDs[4],
+            _resourceID: initialResourceIDs[5],
             _depositer: depositerAddress,
             _metaData: encodedMetaData
         };
         
         const depositTx = await BridgeInstance.deposit(
             chainID,
-            initialResourceIDs[4],
+            initialResourceIDs[5],
             Helpers.createGenericDepositData(encodedMetaData),
             { from: depositerAddress }
         );
@@ -215,10 +233,23 @@ contract('GenericHandler - [deposit]', async (accounts) => {
         const retrievedDepositRecord = await GenericHandlerInstance._depositRecords.call(expectedDepositNonce, chainID);
         Helpers.assertObjectsMatch(expectedDepositRecord, Object.assign({}, retrievedDepositRecord));
 
-        const internalTx = await TruffleAssert.createTransactionResult(ThreeArgumentsInstance, depositTx.tx);
-        TruffleAssert.eventEmitted(internalTx, 'ThreeArgumentsCalled', event =>
+        const internalTx = await TruffleAssert.createTransactionResult(WithDepositerInstance, depositTx.tx);
+        TruffleAssert.eventEmitted(internalTx, 'WithDepositerCalled', event =>
             event.argumentOne === argumentOne &&
-            event.argumentTwo.toNumber() === argumentTwo &&
-            event.argumentThree === argumentThree);
+            event.argumentTwo.toNumber() === argumentTwo);
+    });
+
+    it('depositer is enforced in the metadata', async () => {
+        const anotherDepositer = accounts[2];
+        const argumentOne = anotherDepositer;
+        const argumentTwo = 100;
+        const encodedMetaData = Helpers.abiEncode(['address','uint256'], [argumentOne, argumentTwo]);
+
+        await TruffleAssert.reverts(BridgeInstance.deposit(
+            chainID,
+            initialResourceIDs[5],
+            Helpers.createGenericDepositData(encodedMetaData),
+            { from: depositerAddress }
+        ), 'incorrect depositer in the data');
     });
 });

--- a/test/handlers/generic/executeProposal.js
+++ b/test/handlers/generic/executeProposal.js
@@ -31,6 +31,7 @@ contract('GenericHandler - [Execute Proposal]', async (accounts) => {
     let initialResourceIDs;
     let initialContractAddresses;
     let initialDepositFunctionSignatures;
+    let initialDepositFunctionDepositerOffsets;
     let initialExecuteFunctionSignatures;
     let GenericHandlerInstance;
     let resourceID;
@@ -48,6 +49,7 @@ contract('GenericHandler - [Execute Proposal]', async (accounts) => {
         initialResourceIDs = [resourceID];
         initialContractAddresses = [CentrifugeAssetInstance.address];
         initialDepositFunctionSignatures = [Helpers.blankFunctionSig];
+        initialDepositFunctionDepositerOffsets = [Helpers.blankFunctionDepositerOffset];
         initialExecuteFunctionSignatures = [centrifugeAssetFuncSig];
 
         GenericHandlerInstance = await GenericHandlerContract.new(
@@ -55,9 +57,10 @@ contract('GenericHandler - [Execute Proposal]', async (accounts) => {
             initialResourceIDs,
             initialContractAddresses,
             initialDepositFunctionSignatures,
+            initialDepositFunctionDepositerOffsets,
             initialExecuteFunctionSignatures);
 
-        await BridgeInstance.adminSetGenericResource(GenericHandlerInstance.address, resourceID,  initialContractAddresses[0], initialDepositFunctionSignatures[0], initialExecuteFunctionSignatures[0]);
+        await BridgeInstance.adminSetGenericResource(GenericHandlerInstance.address, resourceID,  initialContractAddresses[0], initialDepositFunctionSignatures[0], initialDepositFunctionDepositerOffsets[0], initialExecuteFunctionSignatures[0]);
 
         depositData = Helpers.createGenericDepositData(hashOfCentrifugeAsset);
         depositProposalDataHash = Ethers.utils.keccak256(GenericHandlerInstance.address + depositData.substr(2));

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -6,6 +6,7 @@
  const Ethers = require('ethers');
 
  const blankFunctionSig = '0x00000000';
+ const blankFunctionDepositerOffset = 0;
  const AbiCoder = new Ethers.utils.AbiCoder;
 
  const toHex = (covertThis, padding) => {
@@ -99,6 +100,7 @@ const nonceAndId = (nonce, id) => {
 module.exports = {
     advanceBlock,
     blankFunctionSig,
+    blankFunctionDepositerOffset,
     toHex,
     abiEncode,
     getFunctionSignature,


### PR DESCRIPTION
This PR's goal is to make Generic Handler useful even for contracts which doesn't know of it's existence. For instance it can now be used as a substitute for ERC handlers, as the depositer can be guaranteed to passed into the target contract without being tampered with, e.g. in **transferFrom** call.

## Changes
- [Breaking] Add **depositFunctionDepositerOffset** param to **Bridge.adminSetGenericResource**.
- If depositer offset parameter is set, then verify that depositer passed from the bridge equals the one in the metadata.
- [Breaking] Add **initialDepositFunctionDepositerOffsets** param to **GenericHandler.constructor**.
- Update Generic Handler tests.
- Add Generic Handler depositer verification tests.

## Closes: #207 