### PR TITLE
Optimize Bridge gas usage

### DIFF
--- a/contracts/Bridge.sol
+++ b/contracts/Bridge.sol
@@ -22,7 +22,7 @@ contract Bridge is Pausable, AccessControl, SafeMath {
     uint8   public _chainID;
     uint8   public _relayerThreshold;
     uint128 public _fee;
-    uint32  public _expiry;
+    uint40  public _expiry;
 
     enum ProposalStatus {Inactive, Active, Passed, Executed, Cancelled}
 
@@ -110,7 +110,7 @@ contract Bridge is Pausable, AccessControl, SafeMath {
         _chainID = chainID;
         _relayerThreshold = initialRelayerThreshold.toUint8();
         _fee = fee.toUint128();
-        _expiry = expiry.toUint32();
+        _expiry = expiry.toUint40();
 
         _setupRole(DEFAULT_ADMIN_ROLE, msg.sender);
 
@@ -346,12 +346,12 @@ contract Bridge is Pausable, AccessControl, SafeMath {
             proposal = Proposal({
                 _status : ProposalStatus.Active,
                 _yesVotes : 0,
-                _yesVotesTotal: 0,
+                _yesVotesTotal : 0,
                 _proposedBlock : uint40(block.number) // Overflow is desired.
             });
 
             emit ProposalEvent(chainID, depositNonce, ProposalStatus.Active, dataHash);
-        } else if (sub(block.number, proposal._proposedBlock) > _expiry) {
+        } else if (uint40(sub(block.number, proposal._proposedBlock)) > _expiry) {
             // if the number of blocks that has passed since this proposal was
             // submitted exceeds the expiry threshold set, cancel the proposal
             proposal._status = ProposalStatus.Cancelled;
@@ -391,7 +391,7 @@ contract Bridge is Pausable, AccessControl, SafeMath {
 
         require(currentStatus == ProposalStatus.Active || currentStatus == ProposalStatus.Passed,
             "Proposal cannot be cancelled");
-        require(sub(block.number, proposal._proposedBlock) > _expiry, "Proposal not at expiry threshold");
+        require(uint40(sub(block.number, proposal._proposedBlock)) > _expiry, "Proposal not at expiry threshold");
 
         proposal._status = ProposalStatus.Cancelled;
         _proposals[nonceAndID][dataHash] = proposal;

--- a/contracts/Bridge.sol
+++ b/contracts/Bridge.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.6.4;
+pragma solidity 0.6.12;
 pragma experimental ABIEncoderV2;
 
 import "./utils/AccessControl.sol";

--- a/contracts/Bridge.sol
+++ b/contracts/Bridge.sol
@@ -1,9 +1,10 @@
 pragma solidity 0.6.4;
 pragma experimental ABIEncoderV2;
 
-import "@openzeppelin/contracts/access/AccessControl.sol";
+import "./utils/AccessControl.sol";
 import "./utils/Pausable.sol";
 import "./utils/SafeMath.sol";
+import "./utils/SafeCast.sol";
 import "./interfaces/IDepositExecute.sol";
 import "./interfaces/IERCHandler.sol";
 import "./interfaces/IGenericHandler.sol";
@@ -13,56 +14,61 @@ import "./interfaces/IGenericHandler.sol";
     @author ChainSafe Systems.
  */
 contract Bridge is Pausable, AccessControl, SafeMath {
+    using SafeCast for *;
 
     uint8   public _chainID;
-    uint256 public _relayerThreshold;
-    uint256 public _totalProposals;
-    uint256 public _fee;
-    uint256 public _expiry;
+    uint8   public _relayerThreshold;
+    uint128 public _fee;
+    uint32  public _expiry;
 
     enum ProposalStatus {Inactive, Active, Passed, Executed, Cancelled}
 
     struct Proposal {
-        bytes32 _resourceID;
-        bytes32 _dataHash;
-        address[] _yesVotes;
-        address[] _noVotes;
         ProposalStatus _status;
-        uint256 _proposedBlock;
+        uint200 _yesVotes;
+        uint8   _yesVotesTotal;
+        uint40  _proposedBlock;
     }
 
     // destinationChainID => number of deposits
     mapping(uint8 => uint64) public _depositCounts;
     // resourceID => handler address
     mapping(bytes32 => address) public _resourceIDToHandlerAddress;
-    // depositNonce => destinationChainID => bytes
-    mapping(uint64 => mapping(uint8 => bytes)) public _depositRecords;
     // destinationChainID + depositNonce => dataHash => Proposal
-    mapping(uint72 => mapping(bytes32 => Proposal)) public _proposals;
-    // destinationChainID + depositNonce => dataHash => relayerAddress => bool
-    mapping(uint72 => mapping(bytes32 => mapping(address => bool))) public _hasVotedOnProposal;
+    mapping(uint72 => mapping(bytes32 => Proposal)) private _proposals;
 
-    event RelayerThresholdChanged(uint indexed newThreshold);
-    event RelayerAdded(address indexed relayer);
-    event RelayerRemoved(address indexed relayer);
+    function _relayerBit(address relayer) private view returns(uint) {
+        return uint(1) << sub(AccessControl.getRoleMemberIndex(RELAYER_ROLE, relayer), 1);
+    }
+
+    function _hasVotedOnProposal(uint72 destNonce, bytes32 dataHash, address relayer) public view returns(bool) {
+        return _hasVoted(_proposals[destNonce][dataHash], relayer);
+    }
+
+    function _hasVoted(Proposal memory proposal, address relayer) private view returns(bool) {
+        return (_relayerBit(relayer) & uint(proposal._yesVotes)) > 0;
+    }
+
+    event RelayerThresholdChanged(uint newThreshold);
+    event RelayerAdded(address relayer);
+    event RelayerRemoved(address relayer);
     event Deposit(
-        uint8   indexed destinationChainID,
-        bytes32 indexed resourceID,
-        uint64  indexed depositNonce
+        uint8   destinationChainID,
+        bytes32 resourceID,
+        uint64  depositNonce
     );
     event ProposalEvent(
-        uint8           indexed originChainID,
-        uint64          indexed depositNonce,
-        ProposalStatus  indexed status,
-        bytes32 resourceID,
+        uint8          originChainID,
+        uint64         depositNonce,
+        ProposalStatus status,
         bytes32 dataHash
     );
 
     event ProposalVote(
-        uint8   indexed originChainID,
-        uint64  indexed depositNonce,
-        ProposalStatus indexed status,
-        bytes32 resourceID
+        uint8   originChainID,
+        uint64  depositNonce,
+        ProposalStatus status,
+        bytes32 dataHash
     );
 
     bytes32 public constant RELAYER_ROLE = keccak256("RELAYER_ROLE");
@@ -102,11 +108,11 @@ contract Bridge is Pausable, AccessControl, SafeMath {
         @param initialRelayers Addresses that should be initially granted the relayer role.
         @param initialRelayerThreshold Number of votes needed for a deposit proposal to be considered passed.
      */
-    constructor (uint8 chainID, address[] memory initialRelayers, uint initialRelayerThreshold, uint256 fee, uint256 expiry) public {
+    constructor (uint8 chainID, address[] memory initialRelayers, uint256 initialRelayerThreshold, uint256 fee, uint256 expiry) public {
         _chainID = chainID;
-        _relayerThreshold = initialRelayerThreshold;
-        _fee = fee;
-        _expiry = expiry;
+        _relayerThreshold = initialRelayerThreshold.toUint8();
+        _fee = fee.toUint128();
+        _expiry = expiry.toUint32();
 
         _setupRole(DEFAULT_ADMIN_ROLE, msg.sender);
 
@@ -158,7 +164,7 @@ contract Bridge is Pausable, AccessControl, SafeMath {
         @notice Emits {RelayerThresholdChanged} event.
      */
     function adminChangeRelayerThreshold(uint newThreshold) external onlyAdmin {
-        _relayerThreshold = newThreshold;
+        _relayerThreshold = newThreshold.toUint8();
         emit RelayerThresholdChanged(newThreshold);
     }
 
@@ -171,6 +177,7 @@ contract Bridge is Pausable, AccessControl, SafeMath {
      */
     function adminAddRelayer(address relayerAddress) external {
         require(!hasRole(RELAYER_ROLE, relayerAddress), "addr already has relayer role!");
+        require(_totalRelayers() < 200, "relayers limit reached");
         grantRole(RELAYER_ROLE, relayerAddress);
         emit RelayerAdded(relayerAddress);
     }
@@ -253,7 +260,7 @@ contract Bridge is Pausable, AccessControl, SafeMath {
         @notice Returns total relayers number.
         @notice Added for backwards compatibility.
      */
-    function _totalRelayers() external view returns (uint) {
+    function _totalRelayers() public view returns (uint) {
         return AccessControl.getRoleMemberCount(RELAYER_ROLE);
     }
 
@@ -264,7 +271,7 @@ contract Bridge is Pausable, AccessControl, SafeMath {
      */
     function adminChangeFee(uint newFee) external onlyAdmin {
         require(_fee != newFee, "Current fee is equal to new fee");
-        _fee = newFee;
+        _fee = newFee.toUint128();
     }
 
     /**
@@ -299,7 +306,6 @@ contract Bridge is Pausable, AccessControl, SafeMath {
         require(handler != address(0), "resourceID not mapped to handler");
 
         uint64 depositNonce = ++_depositCounts[destinationChainID];
-        _depositRecords[depositNonce][destinationChainID] = data;
 
         IDepositExecute depositHandler = IDepositExecute(handler);
         depositHandler.deposit(resourceID, destinationChainID, depositNonce, msg.sender, data);
@@ -321,51 +327,43 @@ contract Bridge is Pausable, AccessControl, SafeMath {
     function voteProposal(uint8 chainID, uint64 depositNonce, bytes32 resourceID, bytes32 dataHash) external onlyRelayers whenNotPaused {
 
         uint72 nonceAndID = (uint72(depositNonce) << 8) | uint72(chainID);
-        Proposal storage proposal = _proposals[nonceAndID][dataHash];
+        Proposal memory proposal = _proposals[nonceAndID][dataHash];
 
         require(_resourceIDToHandlerAddress[resourceID] != address(0), "no handler for resourceID");
         require(uint(proposal._status) <= 1, "proposal already passed/executed/cancelled");
-        require(!_hasVotedOnProposal[nonceAndID][dataHash][msg.sender], "relayer already voted");
+        require(!_hasVoted(proposal, msg.sender), "relayer already voted");
 
-        if (uint(proposal._status) == 0) {
-            ++_totalProposals;
-            _proposals[nonceAndID][dataHash] = Proposal({
-                _resourceID : resourceID,
-                _dataHash : dataHash,
-                _yesVotes : new address[](1),
-                _noVotes : new address[](0),
+        if (proposal._status == ProposalStatus.Inactive) {
+            proposal = Proposal({
                 _status : ProposalStatus.Active,
-                _proposedBlock : block.number
-                });
+                _yesVotes : 0,
+                _yesVotesTotal: 0,
+                _proposedBlock : block.number.toUint40()
+            });
 
-            proposal._yesVotes[0] = msg.sender;
-            emit ProposalEvent(chainID, depositNonce, ProposalStatus.Active, resourceID, dataHash);
-        } else {
-            if (sub(block.number, proposal._proposedBlock) > _expiry) {
-                // if the number of blocks that has passed since this proposal was
-                // submitted exceeds the expiry threshold set, cancel the proposal
-                proposal._status = ProposalStatus.Cancelled;
-                emit ProposalEvent(chainID, depositNonce, ProposalStatus.Cancelled, resourceID, dataHash);
-            } else {
-                require(dataHash == proposal._dataHash, "datahash mismatch");
-                proposal._yesVotes.push(msg.sender);
+            emit ProposalEvent(chainID, depositNonce, ProposalStatus.Active, dataHash);
+        } else if (sub(block.number, proposal._proposedBlock) > _expiry) {
+            // if the number of blocks that has passed since this proposal was
+            // submitted exceeds the expiry threshold set, cancel the proposal
+            proposal._status = ProposalStatus.Cancelled;
 
-
-            }
-
+            emit ProposalEvent(chainID, depositNonce, ProposalStatus.Cancelled, dataHash);
         }
+
         if (proposal._status != ProposalStatus.Cancelled) {
-            _hasVotedOnProposal[nonceAndID][dataHash][msg.sender] = true;
-            emit ProposalVote(chainID, depositNonce, proposal._status, resourceID);
+            proposal._yesVotes = (proposal._yesVotes | _relayerBit(msg.sender)).toUint200();
+            proposal._yesVotesTotal++; // TODO: check if bit counting is cheaper.
+
+            emit ProposalVote(chainID, depositNonce, proposal._status, dataHash);
 
             // Finalize if _relayerThreshold has been reached
-            if (proposal._yesVotes.length >= _relayerThreshold) {
+            if (proposal._yesVotesTotal >= _relayerThreshold) {
                 proposal._status = ProposalStatus.Passed;
 
-                emit ProposalEvent(chainID, depositNonce, ProposalStatus.Passed, resourceID, dataHash);
+                emit ProposalEvent(chainID, depositNonce, ProposalStatus.Passed, dataHash);
             }
         }
-
+        _proposals[nonceAndID][dataHash] = proposal;
     }
 
     /**
@@ -379,7 +377,7 @@ contract Bridge is Pausable, AccessControl, SafeMath {
      */
     function cancelProposal(uint8 chainID, uint64 depositNonce, bytes32 dataHash) public onlyAdminOrRelayer {
         uint72 nonceAndID = (uint72(depositNonce) << 8) | uint72(chainID);
-        Proposal storage proposal = _proposals[nonceAndID][dataHash];
+        Proposal memory proposal = _proposals[nonceAndID][dataHash];
         ProposalStatus currentStatus = proposal._status;
 
         require(currentStatus == ProposalStatus.Active || currentStatus == ProposalStatus.Passed,
@@ -387,7 +385,9 @@ contract Bridge is Pausable, AccessControl, SafeMath {
         require(sub(block.number, proposal._proposedBlock) > _expiry, "Proposal not at expiry threshold");
 
         proposal._status = ProposalStatus.Cancelled;
-        emit ProposalEvent(chainID, depositNonce, ProposalStatus.Cancelled, proposal._resourceID, dataHash);
+        _proposals[nonceAndID][dataHash] = proposal;
+
+        emit ProposalEvent(chainID, depositNonce, ProposalStatus.Cancelled, dataHash);
     }
 
     /**
@@ -408,14 +408,13 @@ contract Bridge is Pausable, AccessControl, SafeMath {
         Proposal storage proposal = _proposals[nonceAndID][dataHash];
 
         require(proposal._status == ProposalStatus.Passed, "Proposal must have Passed status");
-        require(dataHash == proposal._dataHash, "Data doesn't match datahash");
 
         proposal._status = ProposalStatus.Executed;
 
         IDepositExecute depositHandler = IDepositExecute(handler);
-        depositHandler.executeProposal(proposal._resourceID, data);
+        depositHandler.executeProposal(resourceID, data);
 
-        emit ProposalEvent(chainID, depositNonce, ProposalStatus.Executed, resourceID, dataHash);
+        emit ProposalEvent(chainID, depositNonce, ProposalStatus.Executed, dataHash);
     }
 
     /**
@@ -429,5 +428,4 @@ contract Bridge is Pausable, AccessControl, SafeMath {
             addrs[i].transfer(amounts[i]);
         }
     }
-
 }

--- a/contracts/Bridge.sol
+++ b/contracts/Bridge.sol
@@ -117,7 +117,6 @@ contract Bridge is Pausable, AccessControl, SafeMath {
         for (uint256 i; i < initialRelayers.length; i++) {
             grantRole(RELAYER_ROLE, initialRelayers[i]);
         }
-
     }
 
     /**
@@ -348,7 +347,7 @@ contract Bridge is Pausable, AccessControl, SafeMath {
                 _status : ProposalStatus.Active,
                 _yesVotes : 0,
                 _yesVotesTotal: 0,
-                _proposedBlock : block.number.toUint40()
+                _proposedBlock : uint40(block.number) // Overflow is desired.
             });
 
             emit ProposalEvent(chainID, depositNonce, ProposalStatus.Active, dataHash);

--- a/contracts/CentrifugeAsset.sol
+++ b/contracts/CentrifugeAsset.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.6.4;
+pragma solidity 0.6.12;
 pragma experimental ABIEncoderV2;
 
 /**

--- a/contracts/ERC20Safe.sol
+++ b/contracts/ERC20Safe.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.6.4;
+pragma solidity 0.6.12;
 
 import "@openzeppelin/contracts/math/SafeMath.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/contracts/ERC721MinterBurnerPauser.sol
+++ b/contracts/ERC721MinterBurnerPauser.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.6.0;
+pragma solidity 0.6.12;
 
 // This is adapted from https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v3.0.0/contracts/presets/ERC721PresetMinterPauserAutoId.sol
 

--- a/contracts/ERC721MinterBurnerPauser.sol
+++ b/contracts/ERC721MinterBurnerPauser.sol
@@ -2,7 +2,7 @@ pragma solidity ^0.6.0;
 
 // This is adapted from https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v3.0.0/contracts/presets/ERC721PresetMinterPauserAutoId.sol
 
-import "@openzeppelin/contracts/access/AccessControl.sol";
+import "./utils/AccessControl.sol";
 import "@openzeppelin/contracts/GSN/Context.sol";
 import "@openzeppelin/contracts/utils/Counters.sol";
 import "@openzeppelin/contracts/token/ERC721/ERC721.sol";

--- a/contracts/ERC721Safe.sol
+++ b/contracts/ERC721Safe.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.6.4;
+pragma solidity 0.6.12;
 
 import "@openzeppelin/contracts/math/SafeMath.sol";
 import "@openzeppelin/contracts/token/ERC721/IERC721.sol";

--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.6.4;
+pragma solidity 0.6.12;
 
 contract Migrations {
   address public owner;

--- a/contracts/TestContracts.sol
+++ b/contracts/TestContracts.sol
@@ -1,5 +1,7 @@
 pragma solidity 0.6.12;
 
+import "./utils/SafeCast.sol";
+
 contract NoArgument {
     event NoArgumentCalled();
 
@@ -37,5 +39,13 @@ contract WithDepositer {
 
     function withDepositer(address argumentOne, uint256 argumentTwo) external {
         emit WithDepositerCalled(argumentOne, argumentTwo);
+    }
+}
+
+contract SafeCaster {
+    using SafeCast for *;
+
+    function toUint200(uint input) external pure returns(uint200) {
+        return input.toUint200();
     }
 }

--- a/contracts/TestContracts.sol
+++ b/contracts/TestContracts.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.6.4;
+pragma solidity 0.6.12;
 
 contract NoArgument {
     event NoArgumentCalled();

--- a/contracts/handlers/ERC20Handler.sol
+++ b/contracts/handlers/ERC20Handler.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.6.4;
+pragma solidity 0.6.12;
 pragma experimental ABIEncoderV2;
 
 import "../interfaces/IDepositExecute.sol";

--- a/contracts/handlers/ERC721Handler.sol
+++ b/contracts/handlers/ERC721Handler.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.6.4;
+pragma solidity 0.6.12;
 pragma experimental ABIEncoderV2;
 
 import "../interfaces/IDepositExecute.sol";

--- a/contracts/handlers/GenericHandler.sol
+++ b/contracts/handlers/GenericHandler.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.6.4;
+pragma solidity 0.6.12;
 pragma experimental ABIEncoderV2;
 
 import "../interfaces/IGenericHandler.sol";

--- a/contracts/handlers/HandlerHelpers.sol
+++ b/contracts/handlers/HandlerHelpers.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.6.4;
+pragma solidity 0.6.12;
 
 import "../interfaces/IERCHandler.sol";
 

--- a/contracts/interfaces/IBridge.sol
+++ b/contracts/interfaces/IBridge.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.6.4;
+pragma solidity 0.6.12;
 
 /**
     @title Interface for Bridge contract.

--- a/contracts/interfaces/IDepositExecute.sol
+++ b/contracts/interfaces/IDepositExecute.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.6.4;
+pragma solidity 0.6.12;
 
 /**
     @title Interface for handler contracts that support deposits and deposit executions.

--- a/contracts/interfaces/IERCHandler.sol
+++ b/contracts/interfaces/IERCHandler.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.6.4;
+pragma solidity 0.6.12;
 
 /**
     @title Interface to be used with handlers that support ERC20s and ERC721s.

--- a/contracts/interfaces/IGenericHandler.sol
+++ b/contracts/interfaces/IGenericHandler.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.6.4;
+pragma solidity 0.6.12;
 
 /**
     @title Interface for handler that handles generic deposits and deposit executions.

--- a/contracts/utils/AccessControl.sol
+++ b/contracts/utils/AccessControl.sol
@@ -102,7 +102,10 @@ abstract contract AccessControl is Context {
         return _roles[role].members.at(index);
     }
 
-    function getRoleMemberIndex(bytes32 role, address account) public view returns (uint) {
+    /**
+     * @dev Returns the index of the account that have `role`.
+     */
+    function getRoleMemberIndex(bytes32 role, address account) public view returns (uint256) {
         return _roles[role].members._inner._indexes[bytes32(uint256(account))];
     }
 

--- a/contracts/utils/AccessControl.sol
+++ b/contracts/utils/AccessControl.sol
@@ -1,4 +1,6 @@
-pragma solidity ^0.6.0;
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.6.12;
 
 // This is adapted from https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v3.0.0/contracts/access/AccessControl.sol
 // The only difference is added getRoleMemberIndex(bytes32 role, address account) function.

--- a/contracts/utils/AccessControl.sol
+++ b/contracts/utils/AccessControl.sol
@@ -1,0 +1,206 @@
+pragma solidity ^0.6.0;
+
+import "@openzeppelin/contracts/utils/EnumerableSet.sol";
+import "@openzeppelin/contracts/utils/Address.sol";
+import "@openzeppelin/contracts/GSN/Context.sol";
+
+/**
+ * @dev Contract module that allows children to implement role-based access
+ * control mechanisms.
+ *
+ * Roles are referred to by their `bytes32` identifier. These should be exposed
+ * in the external API and be unique. The best way to achieve this is by
+ * using `public constant` hash digests:
+ *
+ * ```
+ * bytes32 public constant MY_ROLE = keccak256("MY_ROLE");
+ * ```
+ *
+ * Roles can be used to represent a set of permissions. To restrict access to a
+ * function call, use {hasRole}:
+ *
+ * ```
+ * function foo() public {
+ *     require(hasRole(MY_ROLE, msg.sender));
+ *     ...
+ * }
+ * ```
+ *
+ * Roles can be granted and revoked dynamically via the {grantRole} and
+ * {revokeRole} functions. Each role has an associated admin role, and only
+ * accounts that have a role's admin role can call {grantRole} and {revokeRole}.
+ *
+ * By default, the admin role for all roles is `DEFAULT_ADMIN_ROLE`, which means
+ * that only accounts with this role will be able to grant or revoke other
+ * roles. More complex role relationships can be created by using
+ * {_setRoleAdmin}.
+ *
+ * WARNING: The `DEFAULT_ADMIN_ROLE` is also its own admin: it has permission to
+ * grant and revoke this role. Extra precautions should be taken to secure
+ * accounts that have been granted it.
+ */
+abstract contract AccessControl is Context {
+    using EnumerableSet for EnumerableSet.AddressSet;
+    using Address for address;
+
+    struct RoleData {
+        EnumerableSet.AddressSet members;
+        bytes32 adminRole;
+    }
+
+    mapping (bytes32 => RoleData) private _roles;
+
+    bytes32 public constant DEFAULT_ADMIN_ROLE = 0x00;
+
+    /**
+     * @dev Emitted when `account` is granted `role`.
+     *
+     * `sender` is the account that originated the contract call, an admin role
+     * bearer except when using {_setupRole}.
+     */
+    event RoleGranted(bytes32 indexed role, address indexed account, address indexed sender);
+
+    /**
+     * @dev Emitted when `account` is revoked `role`.
+     *
+     * `sender` is the account that originated the contract call:
+     *   - if using `revokeRole`, it is the admin role bearer
+     *   - if using `renounceRole`, it is the role bearer (i.e. `account`)
+     */
+    event RoleRevoked(bytes32 indexed role, address indexed account, address indexed sender);
+
+    /**
+     * @dev Returns `true` if `account` has been granted `role`.
+     */
+    function hasRole(bytes32 role, address account) public view returns (bool) {
+        return _roles[role].members.contains(account);
+    }
+
+    /**
+     * @dev Returns the number of accounts that have `role`. Can be used
+     * together with {getRoleMember} to enumerate all bearers of a role.
+     */
+    function getRoleMemberCount(bytes32 role) public view returns (uint256) {
+        return _roles[role].members.length();
+    }
+
+    /**
+     * @dev Returns one of the accounts that have `role`. `index` must be a
+     * value between 0 and {getRoleMemberCount}, non-inclusive.
+     *
+     * Role bearers are not sorted in any particular way, and their ordering may
+     * change at any point.
+     *
+     * WARNING: When using {getRoleMember} and {getRoleMemberCount}, make sure
+     * you perform all queries on the same block. See the following
+     * https://forum.openzeppelin.com/t/iterating-over-elements-on-enumerableset-in-openzeppelin-contracts/2296[forum post]
+     * for more information.
+     */
+    function getRoleMember(bytes32 role, uint256 index) public view returns (address) {
+        return _roles[role].members.at(index);
+    }
+
+    function getRoleMemberIndex(bytes32 role, address account) public view returns (uint) {
+        return _roles[role].members._inner._indexes[bytes32(uint256(account))];
+    }
+
+    /**
+     * @dev Returns the admin role that controls `role`. See {grantRole} and
+     * {revokeRole}.
+     *
+     * To change a role's admin, use {_setRoleAdmin}.
+     */
+    function getRoleAdmin(bytes32 role) public view returns (bytes32) {
+        return _roles[role].adminRole;
+    }
+
+    /**
+     * @dev Grants `role` to `account`.
+     *
+     * If `account` had not been already granted `role`, emits a {RoleGranted}
+     * event.
+     *
+     * Requirements:
+     *
+     * - the caller must have ``role``'s admin role.
+     */
+    function grantRole(bytes32 role, address account) public virtual {
+        require(hasRole(_roles[role].adminRole, _msgSender()), "AccessControl: sender must be an admin to grant");
+
+        _grantRole(role, account);
+    }
+
+    /**
+     * @dev Revokes `role` from `account`.
+     *
+     * If `account` had been granted `role`, emits a {RoleRevoked} event.
+     *
+     * Requirements:
+     *
+     * - the caller must have ``role``'s admin role.
+     */
+    function revokeRole(bytes32 role, address account) public virtual {
+        require(hasRole(_roles[role].adminRole, _msgSender()), "AccessControl: sender must be an admin to revoke");
+
+        _revokeRole(role, account);
+    }
+
+    /**
+     * @dev Revokes `role` from the calling account.
+     *
+     * Roles are often managed via {grantRole} and {revokeRole}: this function's
+     * purpose is to provide a mechanism for accounts to lose their privileges
+     * if they are compromised (such as when a trusted device is misplaced).
+     *
+     * If the calling account had been granted `role`, emits a {RoleRevoked}
+     * event.
+     *
+     * Requirements:
+     *
+     * - the caller must be `account`.
+     */
+    function renounceRole(bytes32 role, address account) public virtual {
+        require(account == _msgSender(), "AccessControl: can only renounce roles for self");
+
+        _revokeRole(role, account);
+    }
+
+    /**
+     * @dev Grants `role` to `account`.
+     *
+     * If `account` had not been already granted `role`, emits a {RoleGranted}
+     * event. Note that unlike {grantRole}, this function doesn't perform any
+     * checks on the calling account.
+     *
+     * [WARNING]
+     * ====
+     * This function should only be called from the constructor when setting
+     * up the initial roles for the system.
+     *
+     * Using this function in any other way is effectively circumventing the admin
+     * system imposed by {AccessControl}.
+     * ====
+     */
+    function _setupRole(bytes32 role, address account) internal virtual {
+        _grantRole(role, account);
+    }
+
+    /**
+     * @dev Sets `adminRole` as ``role``'s admin role.
+     */
+    function _setRoleAdmin(bytes32 role, bytes32 adminRole) internal virtual {
+        _roles[role].adminRole = adminRole;
+    }
+
+    function _grantRole(bytes32 role, address account) private {
+        if (_roles[role].members.add(account)) {
+            emit RoleGranted(role, account, _msgSender());
+        }
+    }
+
+    function _revokeRole(bytes32 role, address account) private {
+        if (_roles[role].members.remove(account)) {
+            emit RoleRevoked(role, account, _msgSender());
+        }
+    }
+}

--- a/contracts/utils/AccessControl.sol
+++ b/contracts/utils/AccessControl.sol
@@ -1,6 +1,7 @@
 pragma solidity ^0.6.0;
 
 // This is adapted from https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v3.0.0/contracts/access/AccessControl.sol
+// The only difference is added getRoleMemberIndex(bytes32 role, address account) function.
 
 import "@openzeppelin/contracts/utils/EnumerableSet.sol";
 import "@openzeppelin/contracts/utils/Address.sol";

--- a/contracts/utils/AccessControl.sol
+++ b/contracts/utils/AccessControl.sol
@@ -1,5 +1,7 @@
 pragma solidity ^0.6.0;
 
+// This is adapted from https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v3.0.0/contracts/access/AccessControl.sol
+
 import "@openzeppelin/contracts/utils/EnumerableSet.sol";
 import "@openzeppelin/contracts/utils/Address.sol";
 import "@openzeppelin/contracts/GSN/Context.sol";

--- a/contracts/utils/Pausable.sol
+++ b/contracts/utils/Pausable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity 0.6.12;
 
 
 /**

--- a/contracts/utils/SafeCast.sol
+++ b/contracts/utils/SafeCast.sol
@@ -15,12 +15,12 @@ library SafeCast {
     }
 
     function toUint32(uint256 value) internal pure returns (uint32) {
-        require(value <= 2**32, "value does not fit in 32 bits");
+        require(value < 2**32, "value does not fit in 32 bits");
         return uint32(value);
     }
 
     function toUint8(uint256 value) internal pure returns (uint8) {
-        require(value <= 2**8, "value does not fit in 8 bits");
+        require(value < 2**8, "value does not fit in 8 bits");
         return uint8(value);
     }
 }

--- a/contracts/utils/SafeCast.sol
+++ b/contracts/utils/SafeCast.sol
@@ -1,4 +1,6 @@
-pragma solidity 0.6.4;
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.6.12;
 
 
 library SafeCast {

--- a/contracts/utils/SafeCast.sol
+++ b/contracts/utils/SafeCast.sol
@@ -1,0 +1,29 @@
+pragma solidity 0.6.4;
+
+
+library SafeCast {
+    function toUint200(uint256 value) internal pure returns (uint200) {
+        require(value < 2**200, "value does not fit in 200 bits");
+        return uint200(value);
+    }
+
+    function toUint128(uint256 value) internal pure returns (uint128) {
+        require(value < 2**128, "value does not fit in 128 bits");
+        return uint128(value);
+    }
+
+    function toUint32(uint256 value) internal pure returns (uint32) {
+        require(value <= 2**32, "value does not fit in 32 bits");
+        return uint32(value);
+    }
+
+    function toUint40(uint256 value) internal pure returns (uint40) {
+        require(value <= 2**40, "value does not fit in 40 bits");
+        return uint40(value);
+    }
+
+    function toUint8(uint256 value) internal pure returns (uint8) {
+        require(value <= 2**8, "value does not fit in 8 bits");
+        return uint8(value);
+    }
+}

--- a/contracts/utils/SafeCast.sol
+++ b/contracts/utils/SafeCast.sol
@@ -14,9 +14,9 @@ library SafeCast {
         return uint128(value);
     }
 
-    function toUint32(uint256 value) internal pure returns (uint32) {
-        require(value < 2**32, "value does not fit in 32 bits");
-        return uint32(value);
+    function toUint40(uint256 value) internal pure returns (uint40) {
+        require(value < 2**40, "value does not fit in 40 bits");
+        return uint40(value);
     }
 
     function toUint8(uint256 value) internal pure returns (uint8) {

--- a/contracts/utils/SafeCast.sol
+++ b/contracts/utils/SafeCast.sol
@@ -19,11 +19,6 @@ library SafeCast {
         return uint32(value);
     }
 
-    function toUint40(uint256 value) internal pure returns (uint40) {
-        require(value <= 2**40, "value does not fit in 40 bits");
-        return uint40(value);
-    }
-
     function toUint8(uint256 value) internal pure returns (uint8) {
         require(value <= 2**8, "value does not fit in 8 bits");
         return uint8(value);

--- a/contracts/utils/SafeMath.sol
+++ b/contracts/utils/SafeMath.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.0;
+pragma solidity 0.6.12;
 
 /**
  * @dev Wrappers over Solidity's arithmetic operations with added overflow
@@ -40,5 +40,4 @@ contract SafeMath {
 
         return c;
     }
-
 }

--- a/test/contractBridge/cancelDepositProposal.js
+++ b/test/contractBridge/cancelDepositProposal.js
@@ -18,7 +18,11 @@ contract('Bridge - [voteProposal with relayerThreshold == 3]', async (accounts) 
     const relayer1Address = accounts[0];
     const relayer2Address = accounts[1];
     const relayer3Address = accounts[2];
-    const relayer4Address = accounts[3]
+    const relayer4Address = accounts[3];
+    const relayer1Bit = 1 << 0;
+    const relayer2Bit = 1 << 1;
+    const relayer3Bit = 1 << 2;
+    const relayer4Bit = 1 << 3;
     const depositerAddress = accounts[4];
     const destinationChainRecipientAddress = accounts[4];
     const depositAmount = 10;
@@ -83,9 +87,8 @@ contract('Bridge - [voteProposal with relayerThreshold == 3]', async (accounts) 
         await TruffleAssert.passes(vote(relayer1Address));
 
         const expectedDepositProposal = {
-            _dataHash: depositDataHash,
-            _yesVotes: [relayer1Address],
-            _noVotes: [],
+            _yesVotes: relayer1Bit.toString(),
+            _yesVotesTotal: '1',
             _status: '1' // Active
         };
 
@@ -108,9 +111,8 @@ contract('Bridge - [voteProposal with relayerThreshold == 3]', async (accounts) 
         await TruffleAssert.passes(vote(relayer2Address));
         
         const expectedDepositProposal = {
-            _dataHash: depositDataHash,
-            _yesVotes: [relayer1Address],
-            _noVotes: [],
+            _yesVotes: relayer1Bit.toString(),
+            _yesVotesTotal: '1',
             _status: '4' // Cancelled
         };
 
@@ -128,9 +130,8 @@ contract('Bridge - [voteProposal with relayerThreshold == 3]', async (accounts) 
         }
 
         const expectedDepositProposal = {
-            _dataHash: depositDataHash,
-            _yesVotes: [relayer2Address],
-            _noVotes: [],
+            _yesVotes: relayer2Bit.toString(),
+            _yesVotesTotal: '1',
             _status: '4' // Cancelled
         };
 
@@ -154,9 +155,8 @@ contract('Bridge - [voteProposal with relayerThreshold == 3]', async (accounts) 
         }
 
         const expectedDepositProposal = {
-            _dataHash: depositDataHash,
-            _yesVotes: [relayer3Address],
-            _noVotes: [],
+            _yesVotes: relayer3Bit.toString(),
+            _yesVotesTotal: '1',
             _status: '4' // Cancelled
         };
 

--- a/test/contractBridge/constructor.js
+++ b/test/contractBridge/constructor.js
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2020 ChainSafe Systems
+ * SPDX-License-Identifier: LGPL-3.0-only
+ */
+const TruffleAssert = require('truffle-assertions');
+const Ethers = require('ethers');
+
+const Helpers = require('../helpers');
+
+const BridgeContract = artifacts.require("Bridge");
+
+contract('Bridge - [constructor]', async accounts => {
+    const chainID = 1;
+    const initialRelayers = accounts.slice(0, 3);
+    const initialRelayerThreshold = 2;
+
+    const expectedBridgeAdmin = accounts[0];
+    const someAddress = "0xcafecafecafecafecafecafecafecafecafecafe";
+    const bytes32 = "0x0";
+    let ADMIN_ROLE;
+    
+    let BridgeInstance;
+
+    const BN = (num) => {
+        return web3.utils.toBN(num);
+    };
+
+    beforeEach(async () => {
+        BridgeInstance = await BridgeContract.new(chainID, initialRelayers, initialRelayerThreshold, 0, 100);
+        ADMIN_ROLE = await BridgeInstance.DEFAULT_ADMIN_ROLE()
+    });
+
+    it('Bridge should not allow to set initialRelayerThreshold above 255', async () => {
+        return TruffleAssert.reverts(BridgeContract.new(chainID, initialRelayers, 256, 0, 100), "value does not fit in 8 bits");
+    });
+
+    it('Bridge should not allow to set fee above 2**128 - 1', async () => {
+        return TruffleAssert.reverts(BridgeContract.new(
+            chainID, initialRelayers, initialRelayerThreshold, web3.utils.toBN(2).pow(web3.utils.toBN(128)), 100), "value does not fit in 128 bits");
+    });
+
+    it('Bridge should not allow to set expiry above 2**32 - 1', async () => {
+        return TruffleAssert.reverts(BridgeContract.new(chainID, initialRelayers, initialRelayerThreshold, 0, BN(2).pow(BN(32))), "value does not fit in 32 bits");
+    });
+});

--- a/test/contractBridge/constructor.js
+++ b/test/contractBridge/constructor.js
@@ -36,7 +36,7 @@ contract('Bridge - [constructor]', async accounts => {
             chainID, initialRelayers, initialRelayerThreshold, BN(2).pow(BN(128)), 100), "value does not fit in 128 bits");
     });
 
-    it('Bridge should not allow to set expiry above 2**32 - 1', async () => {
-        return TruffleAssert.reverts(BridgeContract.new(chainID, initialRelayers, initialRelayerThreshold, 0, BN(2).pow(BN(32))), "value does not fit in 32 bits");
+    it('Bridge should not allow to set expiry above 2**40 - 1', async () => {
+        return TruffleAssert.reverts(BridgeContract.new(chainID, initialRelayers, initialRelayerThreshold, 0, BN(2).pow(BN(40))), "value does not fit in 40 bits");
     });
 });

--- a/test/contractBridge/constructor.js
+++ b/test/contractBridge/constructor.js
@@ -3,9 +3,6 @@
  * SPDX-License-Identifier: LGPL-3.0-only
  */
 const TruffleAssert = require('truffle-assertions');
-const Ethers = require('ethers');
-
-const Helpers = require('../helpers');
 
 const BridgeContract = artifacts.require("Bridge");
 

--- a/test/contractBridge/constructor.js
+++ b/test/contractBridge/constructor.js
@@ -33,7 +33,7 @@ contract('Bridge - [constructor]', async accounts => {
 
     it('Bridge should not allow to set fee above 2**128 - 1', async () => {
         return TruffleAssert.reverts(BridgeContract.new(
-            chainID, initialRelayers, initialRelayerThreshold, web3.utils.toBN(2).pow(web3.utils.toBN(128)), 100), "value does not fit in 128 bits");
+            chainID, initialRelayers, initialRelayerThreshold, BN(2).pow(BN(128)), 100), "value does not fit in 128 bits");
     });
 
     it('Bridge should not allow to set expiry above 2**32 - 1', async () => {

--- a/test/contractBridge/createDepositProposal.js
+++ b/test/contractBridge/createDepositProposal.js
@@ -14,6 +14,7 @@ const ERC20HandlerContract = artifacts.require("ERC20Handler");
 
 contract('Bridge - [create a deposit proposal (voteProposal) with relayerThreshold = 1]', async (accounts) => {
     const originChainRelayerAddress = accounts[1];
+    const originChainRelayerBit = 1 << 0;
     const depositerAddress = accounts[2];
     const destinationRecipientAddress = accounts[3];
     const originChainID = 1;
@@ -101,10 +102,8 @@ contract('Bridge - [create a deposit proposal (voteProposal) with relayerThresho
 
     it('depositProposal should be created with expected values', async () => {
         const expectedDepositProposal = {
-            _resourceID: resourceID,
-            _dataHash: dataHash,
-            _yesVotes: [originChainRelayerAddress],
-            _noVotes: [],
+            _yesVotes: originChainRelayerBit.toString(),
+            _yesVotesTotal: '1',
             _status: '2' // passed
         };
 
@@ -147,7 +146,6 @@ contract('Bridge - [create a deposit proposal (voteProposal) with relayerThresho
             return event.originChainID.toNumber() === originChainID &&
                 event.depositNonce.toNumber() === expectedDepositNonce &&
                 event.status.toNumber() === expectedCreateEventStatus &&
-                event.resourceID === resourceID.toLowerCase() &&
                 event.dataHash === dataHash
         });
     });
@@ -156,6 +154,7 @@ contract('Bridge - [create a deposit proposal (voteProposal) with relayerThresho
 contract('Bridge - [create a deposit proposal (voteProposal) with relayerThreshold > 1]', async (accounts) => {
     // const minterAndRelayer = accounts[0];
     const originChainRelayerAddress = accounts[1];
+    const originChainRelayerBit = 1 << 0;
     const depositerAddress = accounts[2];
     const destinationRecipientAddress = accounts[3];
     const originChainID = 1;
@@ -239,10 +238,8 @@ contract('Bridge - [create a deposit proposal (voteProposal) with relayerThresho
 
     it('depositProposal should be created with expected values', async () => {
         const expectedDepositProposal = {
-            _resourceID: resourceID,
-            _dataHash: dataHash,
-            _yesVotes: [originChainRelayerAddress],
-            _noVotes: [],
+            _yesVotes: originChainRelayerBit.toString(),
+            _yesVotesTotal: '1',
             _status: '1' // active
         };
 
@@ -285,7 +282,6 @@ contract('Bridge - [create a deposit proposal (voteProposal) with relayerThresho
             return event.originChainID.toNumber() === originChainID &&
                 event.depositNonce.toNumber() === expectedDepositNonce &&
                 event.status.toNumber() === expectedCreateEventStatus &&
-                event.resourceID === resourceID.toLowerCase() &&
                 event.dataHash === dataHash
         });
     });

--- a/test/contractBridge/depositERC20.js
+++ b/test/contractBridge/depositERC20.js
@@ -101,18 +101,6 @@ contract('Bridge - [deposit - ERC20]', async (accounts) => {
         assert.strictEqual(originChainHandlerBalance.toNumber(), depositAmount);
     });
 
-    it('depositRecord is created with expected depositNonce and correct value', async () => {
-        await BridgeInstance.deposit(
-            destinationChainID,
-            resourceID,
-            depositData,
-            { from: depositerAddress }
-        );
-
-        const depositRecord = await BridgeInstance._depositRecords.call(expectedDepositNonce, destinationChainID);
-        assert.strictEqual(depositRecord, depositData.toLowerCase(), "Stored depositRecord does not match original depositData");
-    });
-
     it('Deposit event is fired with expected value', async () => {
         let depositTx = await BridgeInstance.deposit(
             destinationChainID,

--- a/test/contractBridge/depositERC721.js
+++ b/test/contractBridge/depositERC721.js
@@ -121,18 +121,6 @@ contract('Bridge - [deposit - ERC721]', async (accounts) => {
         assert.strictEqual(originChainHandlerBalance.toNumber(), 1);
     });
 
-    it('ERC721 deposit record is created with expected depositNonce and values', async () => {
-        await BridgeInstance.deposit(
-            destinationChainID,
-            originResourceID,
-            depositData,
-            { from: depositerAddress }
-        );
-
-        const depositRecord = await BridgeInstance._depositRecords.call(expectedDepositNonce, destinationChainID);
-        assert.strictEqual(depositRecord, depositData.toLowerCase(), "Stored depositRecord does not match original depositData");
-    });
-
     it('Deposit event is fired with expected value', async () => {
         const depositTx = await BridgeInstance.deposit(
             destinationChainID,

--- a/test/contractBridge/depositGeneric.js
+++ b/test/contractBridge/depositGeneric.js
@@ -67,17 +67,6 @@ contract('Bridge - [deposit - Generic]', async () => {
         assert.strictEqual(depositCount.toNumber(), expectedDepositNonce);
     });
 
-    it('Generic deposit is stored correctly', async () => {
-        await BridgeInstance.deposit(
-            destinationChainID,
-            resourceID,
-            depositData
-        );
-        
-        const depositRecord = await BridgeInstance._depositRecords.call(expectedDepositNonce, destinationChainID);
-        assert.strictEqual(depositRecord, depositData.toLowerCase(), "Stored depositRecord does not match original depositData");
-    });
-
     it('Deposit event is fired with expected value after Generic deposit', async () => {
         const depositTx = await BridgeInstance.deposit(
             destinationChainID,

--- a/test/handlers/generic/deposit.js
+++ b/test/handlers/generic/deposit.js
@@ -101,26 +101,7 @@ contract('GenericHandler - [deposit]', async (accounts) => {
         ));
     });
 
-    it('depositRecord is created with expected values', async () => {
-        const expectedDepositRecord = {
-            _destinationChainID: chainID,
-            _resourceID: initialResourceIDs[0],
-            _depositer: depositerAddress,
-            _metaData: '0xdeadbeef'
-        };
-
-        TruffleAssert.passes(await BridgeInstance.deposit(
-            chainID,
-            initialResourceIDs[0],
-            depositData,
-            { from: depositerAddress }
-        ));
-
-        const retrievedDepositRecord = await GenericHandlerInstance._depositRecords.call(expectedDepositNonce, chainID);
-        Helpers.assertObjectsMatch(expectedDepositRecord, Object.assign({}, retrievedDepositRecord));
-    });
-
-    it('noArgument can be called successfully and depositRecord is created with expected values', async () => {
+    it('noArgument can be called successfully', async () => {
         const expectedDepositRecord = {
             _destinationChainID: chainID,
             _resourceID: initialResourceIDs[1],
@@ -135,14 +116,11 @@ contract('GenericHandler - [deposit]', async (accounts) => {
             { from: depositerAddress }
         );
 
-        const retrievedDepositRecord = await GenericHandlerInstance._depositRecords.call(expectedDepositNonce, chainID);
-        Helpers.assertObjectsMatch(expectedDepositRecord, Object.assign({}, retrievedDepositRecord));
-
         const internalTx = await TruffleAssert.createTransactionResult(NoArgumentInstance, depositTx.tx);
         TruffleAssert.eventEmitted(internalTx, 'NoArgumentCalled');
     });
 
-    it('oneArgument can be called successfully and depositRecord is created with expected values', async () => {
+    it('oneArgument can be called successfully', async () => {
         const argumentOne = 42;
         const expectedDepositRecord = {
             _destinationChainID: chainID,
@@ -158,14 +136,11 @@ contract('GenericHandler - [deposit]', async (accounts) => {
             { from: depositerAddress }
         );
 
-        const retrievedDepositRecord = await GenericHandlerInstance._depositRecords.call(expectedDepositNonce, chainID);
-        Helpers.assertObjectsMatch(expectedDepositRecord, Object.assign({}, retrievedDepositRecord));
-
         const internalTx = await TruffleAssert.createTransactionResult(OneArgumentInstance, depositTx.tx);
         TruffleAssert.eventEmitted(internalTx, 'OneArgumentCalled', event => event.argumentOne.toNumber() === argumentOne);
     });
 
-    it('twoArguments can be called successfully and depositRecord is created with expected values', async () => {
+    it('twoArguments can be called successfully', async () => {
         const argumentOne = [NoArgumentInstance.address, OneArgumentInstance.address, TwoArgumentsInstance.address];
         const argumentTwo = initialDepositFunctionSignatures[3];
         const encodedMetaData = Helpers.abiEncode(['address[]','bytes4'], [argumentOne, argumentTwo]);
@@ -183,9 +158,6 @@ contract('GenericHandler - [deposit]', async (accounts) => {
             { from: depositerAddress }
         );
 
-        const retrievedDepositRecord = await GenericHandlerInstance._depositRecords.call(expectedDepositNonce, chainID);
-        Helpers.assertObjectsMatch(expectedDepositRecord, Object.assign({}, retrievedDepositRecord));
-
         const internalTx = await TruffleAssert.createTransactionResult(TwoArgumentsInstance, depositTx.tx);
         TruffleAssert.eventEmitted(internalTx, 'TwoArgumentsCalled', event => {
             return JSON.stringify(event.argumentOne), JSON.stringify(argumentOne) &&
@@ -193,7 +165,7 @@ contract('GenericHandler - [deposit]', async (accounts) => {
         });
     });
 
-    it('threeArguments can be called successfully and depositRecord is created with expected values', async () => {
+    it('threeArguments can be called successfully', async () => {
         const argumentOne = 'soylentGreenIsPeople';
         const argumentTwo = -42;
         const argumentThree = true;
@@ -211,9 +183,6 @@ contract('GenericHandler - [deposit]', async (accounts) => {
             Helpers.createGenericDepositData(encodedMetaData),
             { from: depositerAddress }
         );
-
-        const retrievedDepositRecord = await GenericHandlerInstance._depositRecords.call(expectedDepositNonce, chainID);
-        Helpers.assertObjectsMatch(expectedDepositRecord, Object.assign({}, retrievedDepositRecord));
 
         const internalTx = await TruffleAssert.createTransactionResult(ThreeArgumentsInstance, depositTx.tx);
         TruffleAssert.eventEmitted(internalTx, 'ThreeArgumentsCalled', event =>

--- a/test/handlers/generic/deposit.js
+++ b/test/handlers/generic/deposit.js
@@ -245,6 +245,12 @@ contract('GenericHandler - [deposit]', async (accounts) => {
         const argumentOne = depositerAddress;
         const argumentTwo = 100;
         const encodedMetaData = Helpers.abiEncode(['address','uint256'], [argumentOne, argumentTwo]);
+        const expectedDepositRecord = {
+            _destinationChainID: chainID,
+            _resourceID: initialResourceIDs[5],
+            _depositer: depositerAddress,
+            _metaData: encodedMetaData
+        };
 
         const depositTx = await BridgeInstance.deposit(
             chainID,

--- a/test/safeCast.js
+++ b/test/safeCast.js
@@ -3,9 +3,6 @@
  * SPDX-License-Identifier: LGPL-3.0-only
  */
 const TruffleAssert = require('truffle-assertions');
-const Ethers = require('ethers');
-
-const Helpers = require('../helpers');
 
 const SafeCaster = artifacts.require("SafeCaster");
 

--- a/test/safeCast.js
+++ b/test/safeCast.js
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2020 ChainSafe Systems
+ * SPDX-License-Identifier: LGPL-3.0-only
+ */
+const TruffleAssert = require('truffle-assertions');
+const Ethers = require('ethers');
+
+const Helpers = require('../helpers');
+
+const SafeCaster = artifacts.require("SafeCaster");
+
+contract('Utils - [SafeCast]', async accounts => {
+    let SafeCasterInstance;
+
+    const BN = (num) => web3.utils.toBN(num);
+
+    beforeEach(async () => {
+        SafeCasterInstance = await SafeCaster.new();
+    });
+
+    it('toUint200 should revert if passed value greater than 2**200 - 1', async () => {
+        return TruffleAssert.reverts(SafeCasterInstance.toUint200(BN(2).pow(BN(200))), "value does not fit in 200 bits");
+    });
+});

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -96,7 +96,7 @@ module.exports = {
   // Configure your compilers
   compilers: {
     solc: {
-      version: "0.6.4",       // Fetch exact version from solc-bin (default: truffle's version)
+      version: "0.6.12",       // Fetch exact version from solc-bin (default: truffle's version)
       // docker: true,        // Use "0.5.1" you've installed locally with docker (default: false)
       settings: {          // See the solidity docs for advice about optimization and evmVersion
         optimizer: {


### PR DESCRIPTION
## Changes
- Introduce custom AccessControl with access to member indexes in inner struct. Indexes are needed for relayers bit mapping.
- Reduce **_relayerThreshold**, **_fee**, **_expiry** sizes to fit snugly into storage.
- Remove **_resouceID**, **_dataHash**, **_noVotes** from proposals struct. 
- Make **Proposal._yesVotes** a bitmap instead of an array.
- Introduce **Proposal._yesVotesTotal**.
- Remove **_depositRecords** from storage. One can still maintain an offchain copy while syncing blocks, even though it is not required by ChainBridge.
- Remove indexed arguments from all events. They are expensive and only useful for retrospective filtering.
- Remove **resourceID** from ProposalEvent.
- Add **threeArguments** generic handler test that was accidentally removed before.

Partially closes #201 

#### Closes: n/a
