### PR TITLE
Adds HandlerHelpers to npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "build/contracts/Bridge.json",
     "build/contracts/ERC20Handler.json",
     "build/contracts/ERC721Handler.json",
-    "build/contracts/GenericHandler.json"
+    "build/contracts/GenericHandler.json",
+    "build/contracts/HandlerHelpers.json"
   ],
   "directories": {
     "test": "test"


### PR DESCRIPTION
## Description
Adds HandlerHelpers to package

## Related Issue Or Context
HandlerHelpers is required for reading contract address from `resourceID` on P&L backend so we don't have to store all contract addresses in config file.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have ensured that all acceptance criteria (or expected behavior) from issue are met
- [ ] I have updated the documentation locally and in chainbridge-docs.
- [ ] I have added tests to cover my changes.
- [x] I have ensured that all the checks are passing and green, I've signed the CLA bot
