### PR TITLE
Add `destinationDomainID` to signature in `executeProposals` function

### DIFF
--- a/contracts/Bridge.sol
+++ b/contracts/Bridge.sol
@@ -296,7 +296,7 @@ contract Bridge is Pausable, AccessControl {
     function executeProposals(Proposal[] memory proposals, bytes memory signature) public whenNotPaused {
         require(proposals.length > 0, "Proposals can't be an empty array");
 
-        address signer = keccak256(abi.encode(proposals)).recover(signature);
+        address signer = keccak256(abi.encode(proposals, _domainID)).recover(signature);
         require(signer == _MPCAddress, "Invalid message signer");
 
         for (uint256 i = 0; i < proposals.length; i++) {

--- a/contracts/Bridge.sol
+++ b/contracts/Bridge.sol
@@ -17,10 +17,7 @@ import "./interfaces/IFeeHandler.sol";
 contract Bridge is Pausable, AccessControl {
     using ECDSA for bytes32;
 
-
-
-
-    uint8   public _domainID;
+    uint8   public immutable _domainID;
     address public _MPCAddress;
 
     IFeeHandler public _feeHandler;

--- a/test/contractBridge/executeWithFailedHandler.js
+++ b/test/contractBridge/executeWithFailedHandler.js
@@ -259,7 +259,7 @@ contract('Bridge - [execute - FailedHandlerExecution]', async accounts => {
         // depositNonce is not used
         assert.isFalse(depositProposalBeforeFailedExecute);
 
-        const proposalSignedData = await Helpers.signArrayOfDataWithMpc(proposalsForExecution);
+        const proposalSignedData = await Helpers.signArrayOfDataWithMpc(proposalsForExecution, destinationDomainID);
 
         // depositerAddress makes initial deposit of depositAmount
         await TruffleAssert.passes(BridgeInstance.deposit(

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -187,7 +187,7 @@ const signDataWithMpc = async (originDomainID, destinationDomainID, depositNonce
   return rawSignature
 }
 
-const signArrayOfDataWithMpc = async (proposals) => {
+const signArrayOfDataWithMpc = async (proposals, destinationDomainID) => {
   const signingKey = new Ethers.utils.SigningKey(mpcPrivateKey)
 
   const messageHash = Ethers.utils.keccak256(
@@ -201,8 +201,10 @@ const signArrayOfDataWithMpc = async (proposals) => {
           { name: "resourceID", type: 'bytes32'},
           { name: "data", type: 'bytes'}
         ]
-      }],
-      [proposals]
+      },
+      'uint8'
+      ],
+      [proposals, destinationDomainID]
     )
   );
 


### PR DESCRIPTION
## Description
Add `destinationDomainID` to signature in `executeProposals` function (like it is done in `executeProposal`) so we prevent executing same proposal on multiple networks.

## How Has This Been Tested? Testing details.
Unit tests

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have ensured that all acceptance criteria (or expected behavior) from issue are met
- [ ] I have updated the documentation locally and in chainbridge-docs.
- [x] I have added tests to cover my changes.
- [x] I have ensured that all the checks are passing and green, I've signed the CLA bot
