### PR TITLE
Add `renouceAdmin` function

### DIFF
--- a/contracts/handlers/fee/BasicFeeHandler.sol
+++ b/contracts/handlers/fee/BasicFeeHandler.sol
@@ -37,6 +37,18 @@ contract BasicFeeHandler is IFeeHandler, AccessControl {
     }
 
     /**
+        @notice Removes admin role from {_msgSender()} and grants it to {newAdmin}.
+        @notice Only callable by an address that currently has the admin role.
+        @param newAdmin Address that admin role will be granted to.
+     */
+    function renounceAdmin(address newAdmin) external onlyAdmin {
+        address sender = _msgSender();
+        require(sender != newAdmin, 'Cannot renounce oneself');
+        grantRole(DEFAULT_ADMIN_ROLE, newAdmin);
+        renounceRole(DEFAULT_ADMIN_ROLE, sender);
+    }
+
+    /**
         @notice Collects fee for deposit.
         @param sender Sender of the deposit.
         @param destinationDomainID ID of chain deposit will be bridged to.

--- a/test/handlers/fee/basic/admin.js
+++ b/test/handlers/fee/basic/admin.js
@@ -42,15 +42,15 @@
     });
 
     it('FeeHandlerWithOracle admin should be changed to expectedFeeHandlerWithOracleAdmin', async () => {
-      const expectedFeeHandlerWithOracleAdmin = accounts[1];
+        const expectedFeeHandlerWithOracleAdmin = accounts[1];
 
-      // check current admin
-      assert.isTrue(await BasicFeeHandlerInstance.hasRole(ADMIN_ROLE, currentFeeHandlerAdmin));
+        // check current admin
+        assert.isTrue(await BasicFeeHandlerInstance.hasRole(ADMIN_ROLE, currentFeeHandlerAdmin));
 
-      await TruffleAssert.passes(BasicFeeHandlerInstance.renounceAdmin(expectedFeeHandlerWithOracleAdmin))
-      assert.isTrue(await BasicFeeHandlerInstance.hasRole(ADMIN_ROLE, expectedFeeHandlerWithOracleAdmin));
+        await TruffleAssert.passes(BasicFeeHandlerInstance.renounceAdmin(expectedFeeHandlerWithOracleAdmin))
+        assert.isTrue(await BasicFeeHandlerInstance.hasRole(ADMIN_ROLE, expectedFeeHandlerWithOracleAdmin));
 
-      // check that former admin is no longer admin
-      assert.isFalse(await BasicFeeHandlerInstance.hasRole(ADMIN_ROLE, currentFeeHandlerAdmin));
-  });
+        // check that former admin is no longer admin
+        assert.isFalse(await BasicFeeHandlerInstance.hasRole(ADMIN_ROLE, currentFeeHandlerAdmin));
+    });
 });

--- a/test/handlers/fee/basic/admin.js
+++ b/test/handlers/fee/basic/admin.js
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2022 ChainSafe Systems
+ * SPDX-License-Identifier: LGPL-3.0-only
+ */
+
+ const TruffleAssert = require("truffle-assertions");
+
+ const Helpers = require("../../../helpers");
+
+ const BasicFeeHandlerContract = artifacts.require("BasicFeeHandler");
+
+ contract("BasicFeeHandler - [admin]", async accounts => {
+    const domainID = 1;
+    const initialRelayers = accounts.slice(0, 3);
+    const currentFeeHandlerAdmin = accounts[0];
+
+    const assertOnlyAdmin = (method, ...params) => {
+        return TruffleAssert.reverts(method(...params, {from: initialRelayers[1]}), "sender doesn't have admin role");
+    };
+
+    let BridgeInstance;
+    let BasicFeeHandlerInstance;
+    let ADMIN_ROLE;
+
+    beforeEach(async () => {
+        BridgeInstance = awaitBridgeInstance = await Helpers.deployBridge(domainID, accounts[0]);
+        BasicFeeHandlerInstance = await BasicFeeHandlerContract.new(BridgeInstance.address);
+
+        ADMIN_ROLE = await BasicFeeHandlerInstance.DEFAULT_ADMIN_ROLE();
+    });
+
+    it("should set fee property", async () => {
+        const fee = 3;
+        assert.equal(await BasicFeeHandlerInstance._fee.call(), "0");
+        await BasicFeeHandlerInstance.changeFee(fee);
+        assert.equal(await BasicFeeHandlerInstance._fee.call(), fee);
+    });
+
+    it("should require admin role to change fee property", async () => {
+        const fee = 3;
+        await assertOnlyAdmin(BasicFeeHandlerInstance.changeFee, fee);
+    });
+
+    it('FeeHandlerWithOracle admin should be changed to expectedFeeHandlerWithOracleAdmin', async () => {
+      const expectedFeeHandlerWithOracleAdmin = accounts[1];
+
+      // check current admin
+      assert.isTrue(await BasicFeeHandlerInstance.hasRole(ADMIN_ROLE, currentFeeHandlerAdmin));
+
+      await TruffleAssert.passes(BasicFeeHandlerInstance.renounceAdmin(expectedFeeHandlerWithOracleAdmin))
+      assert.isTrue(await BasicFeeHandlerInstance.hasRole(ADMIN_ROLE, expectedFeeHandlerWithOracleAdmin));
+
+      // check that former admin is no longer admin
+      assert.isFalse(await BasicFeeHandlerInstance.hasRole(ADMIN_ROLE, currentFeeHandlerAdmin));
+  });
+});

--- a/test/handlers/fee/withOracle/admin.js
+++ b/test/handlers/fee/withOracle/admin.js
@@ -59,15 +59,15 @@
     });
 
     it('FeeHandlerWithOracle admin should be changed to expectedFeeHandlerWithOracleAdmin', async () => {
-      const expectedFeeHandlerWithOracleAdmin = accounts[1];
+        const expectedFeeHandlerWithOracleAdmin = accounts[1];
 
-      // check current admin
-      assert.isTrue(await FeeHandlerWithOracleInstance.hasRole(ADMIN_ROLE, currentFeeHandlerAdmin));
+        // check current admin
+        assert.isTrue(await FeeHandlerWithOracleInstance.hasRole(ADMIN_ROLE, currentFeeHandlerAdmin));
 
-      await TruffleAssert.passes(FeeHandlerWithOracleInstance.renounceAdmin(expectedFeeHandlerWithOracleAdmin))
-      assert.isTrue(await FeeHandlerWithOracleInstance.hasRole(ADMIN_ROLE, expectedFeeHandlerWithOracleAdmin));
+        await TruffleAssert.passes(FeeHandlerWithOracleInstance.renounceAdmin(expectedFeeHandlerWithOracleAdmin))
+        assert.isTrue(await FeeHandlerWithOracleInstance.hasRole(ADMIN_ROLE, expectedFeeHandlerWithOracleAdmin));
 
-      // check that former admin is no longer admin
-      assert.isFalse(await FeeHandlerWithOracleInstance.hasRole(ADMIN_ROLE, currentFeeHandlerAdmin));
-  });
+        // check that former admin is no longer admin
+        assert.isFalse(await FeeHandlerWithOracleInstance.hasRole(ADMIN_ROLE, currentFeeHandlerAdmin));
+    });
 });

--- a/test/handlers/fee/withOracle/admin.js
+++ b/test/handlers/fee/withOracle/admin.js
@@ -12,6 +12,7 @@
  contract("FeeHandlerWithOracle - [admin]", async accounts => {
     const domainID = 1;
     const initialRelayers = accounts.slice(0, 3);
+    const currentFeeHandlerAdmin = accounts[0];
 
     const assertOnlyAdmin = (method, ...params) => {
         return TruffleAssert.reverts(method(...params, {from: initialRelayers[1]}), "sender doesn't have admin role");
@@ -19,10 +20,13 @@
 
     let BridgeInstance;
     let FeeHandlerWithOracleInstance;
+    let ADMIN_ROLE;
 
     beforeEach(async () => {
         BridgeInstance = awaitBridgeInstance = await Helpers.deployBridge(domainID, accounts[0]);
         FeeHandlerWithOracleInstance = await FeeHandlerWithOracleContract.new(BridgeInstance.address);
+
+        ADMIN_ROLE = await FeeHandlerWithOracleInstance.DEFAULT_ADMIN_ROLE();
     });
 
     it("should set fee oracle", async () => {
@@ -53,4 +57,17 @@
         const feePercent = 5;
         await assertOnlyAdmin(FeeHandlerWithOracleInstance.setFeeProperties, gasUsed, feePercent);
     });
+
+    it('FeeHandlerWithOracle admin should be changed to expectedFeeHandlerWithOracleAdmin', async () => {
+      const expectedFeeHandlerWithOracleAdmin = accounts[1];
+
+      // check current admin
+      assert.isTrue(await FeeHandlerWithOracleInstance.hasRole(ADMIN_ROLE, currentFeeHandlerAdmin));
+
+      await TruffleAssert.passes(FeeHandlerWithOracleInstance.renounceAdmin(expectedFeeHandlerWithOracleAdmin))
+      assert.isTrue(await FeeHandlerWithOracleInstance.hasRole(ADMIN_ROLE, expectedFeeHandlerWithOracleAdmin));
+
+      // check that former admin is no longer admin
+      assert.isFalse(await FeeHandlerWithOracleInstance.hasRole(ADMIN_ROLE, currentFeeHandlerAdmin));
+  });
 });


### PR DESCRIPTION
## Description
Adds `renouceAdmin` function so we are able to change `FeeHandlers` admin

## Related Issue Or Context
Closes: #584 

## How Has This Been Tested? Testing details.
Unit tests

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have ensured that all acceptance criteria (or expected behavior) from issue are met
- [ ] I have updated the documentation locally and in chainbridge-docs.
- [x] I have added tests to cover my changes.
- [x] I have ensured that all the checks are passing and green, I've signed the CLA bot
